### PR TITLE
infra/DANG-994: startDate와 endDate 변수 선언 분리

### DIFF
--- a/backend/src/statistics/statistics.service.ts
+++ b/backend/src/statistics/statistics.service.ts
@@ -60,7 +60,8 @@ export class StatisticsService {
     }
 
     async getDogWalkCnt(userId: number, dogId: number, date: string, period: Period) {
-        let startDate: Date, endDate: Date;
+        let startDate: Date;
+        let endDate: Date;
         startDate = endDate = new Date();
 
         if (period === 'month') {


### PR DESCRIPTION
## 작업 내용 (Content)
- getDogWalkCnt 함수 내에서 startDate와 endDate 변수 선언을 한 줄로 합쳐져 있던 것을 각각 분리하여 가독성을 향상시켰습니다.
- 변수 타입은 명시적으로 Date로 지정했습니다.

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
