### PR TITLE
backend/DANG-945: WalkController e2e test 코드 작성

### DIFF
--- a/backend/src/dogs/dogs.service.ts
+++ b/backend/src/dogs/dogs.service.ts
@@ -94,16 +94,14 @@ export class DogsService {
         return this.dogsRepository.update({ id: dogId }, updateData);
     }
 
-    async updateIsWalking(dogIds: number[] | number, stateToUpdate: boolean) {
+    async updateIsWalking(dogIds: number | number[], stateToUpdate: boolean) {
+        dogIds = Array.isArray(dogIds) ? dogIds : [dogIds];
+
         const attrs = {
             isWalking: stateToUpdate,
         };
 
-        if (Array.isArray(dogIds)) {
-            await this.dogsRepository.update({ id: In(dogIds) }, attrs);
-        } else {
-            await this.dogsRepository.update({ id: dogIds }, attrs);
-        }
+        await this.dogsRepository.update({ id: In(dogIds) }, attrs);
 
         return dogIds;
     }

--- a/backend/src/journals/guards/auth-journal.guard.ts
+++ b/backend/src/journals/guards/auth-journal.guard.ts
@@ -15,7 +15,7 @@ export class AuthJournalGuard implements CanActivate {
         const { userId } = request.user;
         const journalId = parseInt(request.params.id);
 
-        const owned = await this.journalsService.checkJournalOwnership(userId, journalId);
+        const [owned] = await this.journalsService.checkJournalOwnership(userId, journalId);
 
         if (!owned) {
             const error = new ForbiddenException(`User ${userId} does not have access to journal ${journalId}`);

--- a/backend/src/journals/journals.service.ts
+++ b/backend/src/journals/journals.service.ts
@@ -68,7 +68,7 @@ export class JournalsService {
         return ownJournals.map((cur) => cur.id);
     }
 
-    async checkJournalOwnership(userId: number, journalIds: number | number[]): Promise<boolean> {
+    async checkJournalOwnership(userId: number, journalIds: number | number[]): Promise<[boolean, number[]]> {
         const myJournalIds = await this.getOwnJournalIds(userId);
         return checkIfExistsInArr(myJournalIds, journalIds);
     }

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -70,12 +70,11 @@ export class UsersService {
         return foundDogs.map((cur) => cur.dogId);
     }
 
-    async checkDogOwnership(userId: number, dogId: number | number[]): Promise<boolean> {
+    async checkDogOwnership(userId: number, dogId: number | number[]): Promise<[boolean, number[]]> {
         const ownDogs = await this.usersDogsService.find({ userId });
         const myDogIds = ownDogs.map((cur) => cur.dogId);
 
-        const result = checkIfExistsInArr(myDogIds, dogId);
-        return result;
+        return checkIfExistsInArr(myDogIds, dogId);
     }
 
     async getUserProfile({ userId, provider }: AccessTokenPayload): Promise<UserProfile> {

--- a/backend/src/utils/manipulate.util.ts
+++ b/backend/src/utils/manipulate.util.ts
@@ -2,21 +2,22 @@
  * 주어진 배열에 값이나 값의 배열이 존재하는지 확인합니다.
  *
  * 이 함수는 배열의 어떤 타입에도 작동할 수 있는 제네릭 함수입니다.
- * * `targetArr`라는 매개변수를 통해 검색할 배열을, `toFind`라는 매개변수를 통해 검색할 값이나 값의 배열을 받습니다.
+ * `targetArr` 매개변수를 통해 검색할 배열을 받고, `toFind` 매개변수를 통해 검색할 값이나 값의 배열을 받습니다.
  *
- * `toFind`가 배열인 경우, 함수는 `toFind`의 모든 요소가 `targetArr`에 포함되어 있는지 확인합니다.
- * `toFind`가 단일 값인 경우, 함수는 `toFind`가 `targetArr`에 포함되어 있는지 확인합니다.
- *
- * 조건이 충족되면 `true`, 그렇지 않으면 `false`를 반환합니다.
+ * 함수는 [`toFind`가 `targetArr`에 존재하는지 여부, 존재하지 않는 값 배열]을 반환합니다.
  *
  * @template T - `targetArr`와 `toFind`의 요소 타입.
  * @param targetArr - 검색할 배열.
  * @param toFind - 검색할 값이나 값의 배열.
- * @returns `toFind`가 `targetArr`에 존재하면 `true`, 그렇지 않으면 `false`.
+ * @returns [`toFind`가 `targetArr`에 존재하는지 여부, 존재하지 않는 값 배열]
  *
  **/
-export function checkIfExistsInArr<T>(targetArr: T[], toFind: T | T[]): boolean {
-    return Array.isArray(toFind) ? toFind.every((cur) => targetArr.includes(cur)) : targetArr.includes(toFind);
+export function checkIfExistsInArr<T>(targetArr: T[], toFind: T | T[]): [boolean, T[]] {
+    const toFindList = Array.isArray(toFind) ? toFind : [toFind];
+
+    const notFound = toFindList.filter((cur) => !targetArr.includes(cur));
+
+    return [notFound.length === 0, notFound];
 }
 
 /**

--- a/backend/src/walk/dtos/walk-command.dto.ts
+++ b/backend/src/walk/dtos/walk-command.dto.ts
@@ -1,6 +1,0 @@
-import { IsArray } from 'class-validator';
-
-export class WalkCommandDto {
-    @IsArray()
-    dogId: string[];
-}

--- a/backend/test/walk.e2e-spec.ts
+++ b/backend/test/walk.e2e-spec.ts
@@ -1,0 +1,120 @@
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+
+import { VALID_ACCESS_TOKEN_100_YEARS } from './constants';
+import {
+    clearDogs,
+    clearUsers,
+    closeTestApp,
+    insertMockDogs,
+    insertMockUser,
+    setupTestApp,
+    testUnauthorizedAccess,
+} from './test-utils';
+
+import { mockDog2Profile, mockDogProfile } from '../src/fixtures/dogs.fixture';
+
+describe('WalkController (e2e)', () => {
+    let app: INestApplication;
+
+    beforeAll(async () => {
+        ({ app } = await setupTestApp());
+    });
+
+    beforeEach(async () => {
+        await insertMockUser();
+        await insertMockDogs();
+    });
+
+    afterEach(async () => {
+        await clearDogs();
+        await clearUsers();
+    });
+
+    afterAll(async () => {
+        await closeTestApp();
+    });
+
+    describe('/dogs/walks/start (POST)', () => {
+        context('사용자가 소유한 강아지 목록으로 산책 시작 요청을 보내면', () => {
+            it('200 상태 코드와 강아지 목록을 반환해야 한다.', async () => {
+                const response = await request(app.getHttpServer())
+                    .post('/dogs/walks/start')
+                    .set('Authorization', `Bearer ${VALID_ACCESS_TOKEN_100_YEARS}`)
+                    .send([1, 2])
+                    .expect(200);
+
+                expect(response.body).toEqual([1, 2]);
+            });
+        });
+
+        context('사용자가 소유하지 않은 강아지가 포함된 목록으로 산책 시작 요청을 보내면', () => {
+            it('403 상태 코드를 반환해야 한다.', () => {
+                return request(app.getHttpServer())
+                    .post('/dogs/walks/start')
+                    .set('Authorization', `Bearer ${VALID_ACCESS_TOKEN_100_YEARS}`)
+                    .send([1, 2, 3])
+                    .expect(403);
+            });
+        });
+
+        // TODO: invalid request body에 대한 test case 추가하기
+
+        testUnauthorizedAccess('산책 시작', 'post', '/dogs/walks/start');
+    });
+
+    describe('/dogs/walks/stop (POST)', () => {
+        context('사용자가 소유한 강아지 목록으로 산책 종료 요청을 보내면', () => {
+            it('200 상태 코드와 강아지 목록을 반환해야 한다.', async () => {
+                const response = await request(app.getHttpServer())
+                    .post('/dogs/walks/stop')
+                    .set('Authorization', `Bearer ${VALID_ACCESS_TOKEN_100_YEARS}`)
+                    .send([1, 2])
+                    .expect(200);
+
+                expect(response.body).toEqual([1, 2]);
+            });
+        });
+
+        context('사용자가 소유하지 않은 강아지가 포함된 목록으로 산책 종료 요청을 보내면', () => {
+            it('403 상태 코드를 반환해야 한다.', () => {
+                return request(app.getHttpServer())
+                    .post('/dogs/walks/stop')
+                    .set('Authorization', `Bearer ${VALID_ACCESS_TOKEN_100_YEARS}`)
+                    .send([1, 2, 3])
+                    .expect(403);
+            });
+        });
+
+        // TODO: invalid request body에 대한 test case 추가하기
+
+        testUnauthorizedAccess('산책 종료', 'post', '/dogs/walks/stop');
+    });
+
+    describe('/dogs/walks/available (POST)', () => {
+        context('사용자가 산책 가능한 강아지 목록 조회 요청을 보내면', () => {
+            it('200 상태 코드와 강아지 목록을 반환해야 한다.', async () => {
+                const response = await request(app.getHttpServer())
+                    .get('/dogs/walks/available')
+                    .set('Authorization', `Bearer ${VALID_ACCESS_TOKEN_100_YEARS}`)
+                    .send([1, 2])
+                    .expect(200);
+
+                expect(response.body).toEqual([
+                    {
+                        id: mockDogProfile.id,
+                        name: mockDogProfile.name,
+                        profilePhotoUrl: mockDogProfile.profilePhotoUrl,
+                    },
+                    {
+                        id: mockDog2Profile.id,
+                        name: mockDog2Profile.name,
+                        profilePhotoUrl: mockDog2Profile.profilePhotoUrl,
+                    },
+                ]);
+            });
+        });
+
+        testUnauthorizedAccess('산책 가능한 강아지 목록 조회', 'get', '/dogs/walks/available');
+    });
+});


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
```bash
$ npm run test:e2e -- --testPathPattern=test/walk.e2e-spec.ts

> nest-js-example@0.0.1 test:e2e
> cross-env NODE_ENV=test jest --config ./test/jest-e2e.json --maxWorkers=1 --testPathPattern=test/walk.e2e-spec.ts

 PASS  test/walk.e2e-spec.ts (8.986 s)
  WalkController (e2e)
    /dogs/walks/start (POST)                                                                                                                                                   
      사용자가 소유한 강아지 목록으로 산책 시작 요청을 보내면                                                                                                                  
        √ 200 상태 코드와 강아지 목록을 반환해야 한다. (107 ms)                                                                                                                
      사용자가 소유하지 않은 강아지가 포함된 목록으로 산책 시작 요청을 보내면                                                                                                  
        √ 403 상태 코드를 반환해야 한다. (68 ms)                                                                                                                               
      Authorization header 없이 산책 시작 요청을 보내면                                                                                                                        
        √ 401 상태 코드를 반환해야 한다. (62 ms)                                                                                                                               
      구조가 잘못된 access token을 Authorization header에 담아 산책 시작 요청을 보내면
        √ 401 상태 코드를 반환해야 한다. (56 ms)                                                                                                                               
      만료된 access token을 Authorization header에 담아 산책 시작 요청을 보내면                                                                                                
        √ 401 상태 코드를 반환해야 한다. (54 ms)                                                                                                                               
      존재하지 않는 userId를 가진 access token을 Authorization header에 담아 산책 시작 요청을 보내면                                                                           
        √ 401 상태 코드를 반환해야 한다. (53 ms)                                                                                                                               
    /dogs/walks/stop (POST)                                                                                                                                                    
      사용자가 소유한 강아지 목록으로 산책 종료 요청을 보내면                                                                                                                  
        √ 200 상태 코드와 강아지 목록을 반환해야 한다. (55 ms)                                                                                                                 
      사용자가 소유하지 않은 강아지가 포함된 목록으로 산책 종료 요청을 보내면                                                                                                  
        √ 403 상태 코드를 반환해야 한다. (58 ms)                                                                                                                               
      Authorization header 없이 산책 종료 요청을 보내면                                                                                                                        
        √ 401 상태 코드를 반환해야 한다. (55 ms)                                                                                                                               
      구조가 잘못된 access token을 Authorization header에 담아 산책 종료 요청을 보내면                                                                                         
        √ 401 상태 코드를 반환해야 한다. (49 ms)                                                                                                                               
      만료된 access token을 Authorization header에 담아 산책 종료 요청을 보내면                                                                                                
        √ 401 상태 코드를 반환해야 한다. (53 ms)                                                                                                                               
      존재하지 않는 userId를 가진 access token을 Authorization header에 담아 산책 종료 요청을 보내면                                                                           
        √ 401 상태 코드를 반환해야 한다. (54 ms)                                                                                                                               
    /dogs/walks/available (POST)                                                                                                                                               
      사용자가 산책 가능한 강아지 목록 조회 요청을 보내면                                                                                                                      
        √ 200 상태 코드와 강아지 목록을 반환해야 한다. (94 ms)                                                                                                                 
      Authorization header 없이 산책 가능한 강아지 목록 조회 요청을 보내면                                                                                                     
        √ 401 상태 코드를 반환해야 한다. (60 ms)                                                                                                                               
      구조가 잘못된 access token을 Authorization header에 담아 산책 가능한 강아지 목록 조회 요청을 보내면                                                                      
        √ 401 상태 코드를 반환해야 한다. (53 ms)                                                                                                                               
      만료된 access token을 Authorization header에 담아 산책 가능한 강아지 목록 조회 요청을 보내면                                                                             
        √ 401 상태 코드를 반환해야 한다. (55 ms)                                                                                                                               
      존재하지 않는 userId를 가진 access token을 Authorization header에 담아 산책 가능한 강아지 목록 조회 요청을 보내면                                                        
        √ 401 상태 코드를 반환해야 한다. (60 ms)                                                                                                                               
                                                                                                                                                                               
Test Suites: 1 passed, 1 total                                                                                                                                                 
Tests:       17 passed, 17 total                                                                                                                                               
Snapshots:   0 total
Time:        9.092 s, estimated 15 s
Ran all test suites matching /test\\walk.e2e-spec.ts/i.
```

## 링크 (Links)
https://www.notion.so/do0ori/WalkController-e2e-test-6742b3f0913540ed86caed848e70af86

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
