### PR TITLE
backend/DANG-1000: 서버 이전에 따른 Set-Cookie option 수정

### DIFF
--- a/backend/src/auth/interceptors/cookie.interceptor.ts
+++ b/backend/src/auth/interceptors/cookie.interceptor.ts
@@ -19,7 +19,6 @@ export class CookieInterceptor implements NestInterceptor {
 
     private readonly sessionCookieOptions: CookieOptions = {
         httpOnly: true,
-        sameSite: this.isProduction ? 'none' : 'lax',
         secure: this.isProduction,
     };
 


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
배포환경에서 client는 `'https://dangdang-walk.xyz'`, server는 `'https://api.dangdang-walk.xyz'`를 사용하게 되면서 same-site 환경이 되었다. 따라서 sameSite option은 default 값인 `'lax'`를 그대로 사용한다.
domain option은 따로 설정하지 않으면 자동으로 `api.dangdang-walk.xyz`가 되는데 어차피 모든 요청을 여기서 처리할 것이기 때문에 따로 설정하지 않았다.

## 링크 (Links)
https://www.notion.so/do0ori/Set-Cookie-option-01a11cf397c5415d91a69b83ee280aff

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
