### PR TITLE
backend/DANG-1016: 회원가입시 디폴트 프로필 이미지 사용하도록 변경

### DIFF
--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -16,6 +16,8 @@ import { S3Service } from '../s3/s3.service';
 import { Users } from '../users/users.entity';
 import { UsersService } from '../users/users.service';
 
+const S3_PROFILE_IMAGE_PATH = 'default/profile.png';
+
 @Injectable()
 export class AuthService {
     constructor(
@@ -62,8 +64,8 @@ export class AuthService {
     }
 
     async signup({ oauthAccessToken, oauthRefreshToken, provider }: OauthData): Promise<AuthData> {
-        const { oauthId, oauthNickname, email, profileImageUrl } =
-            await this[`${provider}Service`].requestUserInfo(oauthAccessToken);
+        const { oauthId, oauthNickname, email } = await this[`${provider}Service`].requestUserInfo(oauthAccessToken);
+        const profileImageUrl = S3_PROFILE_IMAGE_PATH;
 
         const refreshToken = this.tokenService.signRefreshToken(oauthId, provider);
         this.logger.debug('signup - signRefreshToken', { refreshToken });

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -32,12 +32,13 @@ export class AuthService {
         private readonly logger: WinstonLoggerService,
     ) {}
 
-    private readonly redirectURI = this.configService.get<string>('CORS_ORIGIN') + '/callback';
+    private readonly REDIRECT_URI = this.configService.get<string>('CORS_ORIGIN') + '/callback';
+    private readonly S3_PROFILE_IMAGE_PATH = 'default/profile.png';
 
     async login({ authorizeCode, provider }: OauthAuthorizeData): Promise<AuthData | OauthData | undefined> {
         const { access_token: oauthAccessToken, refresh_token: oauthRefreshToken } = await this[
             `${provider}Service`
-        ].requestToken(authorizeCode, this.redirectURI);
+        ].requestToken(authorizeCode, this.REDIRECT_URI);
 
         const { oauthId } = await this[`${provider}Service`].requestUserInfo(oauthAccessToken);
 
@@ -65,7 +66,7 @@ export class AuthService {
 
     async signup({ oauthAccessToken, oauthRefreshToken, provider }: OauthData): Promise<AuthData> {
         const { oauthId, oauthNickname, email } = await this[`${provider}Service`].requestUserInfo(oauthAccessToken);
-        const profileImageUrl = S3_PROFILE_IMAGE_PATH;
+        const profileImageUrl = this.S3_PROFILE_IMAGE_PATH;
 
         const refreshToken = this.tokenService.signRefreshToken(oauthId, provider);
         this.logger.debug('signup - signRefreshToken', { refreshToken });


### PR DESCRIPTION
## 작업 내용 (Content)
url -> path로 통일하기 위해 
기존에 사용하던 oauth에서 가져온 프로필 이미지 url을 사용하지 않고,
s3에 올라가 있는 디폴트 프로필 이미지를 사용하도록 변경하였습니다.

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
