### PR TITLE
backend/DANG-1018: updateJournal에 @Transactional 적용 시 요청이 hang되는 오류 해결하기

### DIFF
--- a/backend/src/common/database/abstract.repository.ts
+++ b/backend/src/common/database/abstract.repository.ts
@@ -17,7 +17,7 @@ export abstract class AbstractRepository<T extends ObjectLiteral> {
     ) {}
 
     async create(entity: T): Promise<T> {
-        return this.entityManager.save(entity);
+        return this.entityRepository.save(entity);
     }
 
     /**

--- a/backend/src/common/database/database.module.ts
+++ b/backend/src/common/database/database.module.ts
@@ -30,6 +30,8 @@ import { WinstonLoggerService } from '../logger/winstonLogger.service';
                     synchronize: true,
                     timezone: 'Z',
                     legacySpatialSupport: false,
+                    logging: true,
+                    logger: 'file',
                 };
             },
             async dataSourceFactory(options) {

--- a/backend/src/journals/journals.service.ts
+++ b/backend/src/journals/journals.service.ts
@@ -2,6 +2,8 @@ import { Injectable } from '@nestjs/common';
 import { DeleteResult, EntityManager, FindOptionsWhere, In } from 'typeorm';
 import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
 
+import { Transactional } from 'typeorm-transactional';
+
 import { Journals } from './journals.entity';
 
 import { JournalsRepository } from './journals.repository';
@@ -180,7 +182,7 @@ export class JournalsService {
         }
     }
 
-    //@Transactional()
+    @Transactional()
     async createJournal(userId: number, createJournalData: CreateJournalData) {
         const dogIds = createJournalData.dogs;
         const journalData = this.makeJournalData(userId, createJournalData.journalInfo);
@@ -205,7 +207,7 @@ export class JournalsService {
         );
     }
 
-    // @Transactional()
+    @Transactional()
     async updateJournal(journalId: number, updateJournalData: UpdateJournalData) {
         if (updateJournalData.memo) {
             await this.updateAndFindOne({ id: journalId }, { memo: updateJournalData.memo });


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- query logging 추가 - 가장 가까운 package.json 파일이 존재하는 root 폴더에 ormlogs.log 파일에 생성되며 여기에 log가 저장된다.
- `entityManager.save`로 entity를 insert하면 새로운 entityManager가 생성되어 @Transactional 적용 시 문제가 발생하기 때문에 수정했다.
- 추상 리포지토리에서 entityManager를 사용하는 method는 없지만 추상 리포지토리를 상속받는 리포지토리에서 entityManager를 사용하고 있으므로 주입해둔다.
- JournalsService에 transaction 적용

## 링크 (Links)
https://www.notion.so/do0ori/updateJournal-Transactional-hang-4c094889200e4d03a5d0bbe5eb85a3bc
https://www.notion.so/do0ori/Transactional-Lock-wait-timeout-exceeded-634ef101b1624bf7879875a36edbb800

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
