### PR TITLE
backend/DANG-1021: Guard refactoring

### DIFF
--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -140,16 +140,26 @@ export class AuthService {
         await this.s3Service.deleteObjectFolder(userId);
     }
 
-    async validateAccessToken(userId: number) {
-        const result = await this.usersService.findOne({ id: userId });
+    async validateAccessToken(token: string): Promise<AccessTokenPayload> {
+        const payload = this.tokenService.verify(token) as AccessTokenPayload;
+        this.logger.log('Payload', payload);
+
+        const result = await this.usersService.findOne({ id: payload.userId });
         this.logger.debug('validateAccessToken - find User result', { ...result });
+
+        return payload;
     }
 
-    async validateRefreshToken(token: string, oauthId: string) {
-        const { refreshToken } = await this.usersService.findOne({ oauthId });
+    async validateRefreshToken(token: string): Promise<RefreshTokenPayload> {
+        const payload = this.tokenService.verify(token) as RefreshTokenPayload;
+        this.logger.log('Payload', payload);
+
+        const { refreshToken } = await this.usersService.findOne({ oauthId: payload.oauthId });
 
         if (refreshToken !== token) {
             throw new UnauthorizedException();
         }
+
+        return payload;
     }
 }

--- a/backend/src/auth/guards/oauth-data.guard.ts
+++ b/backend/src/auth/guards/oauth-data.guard.ts
@@ -7,6 +7,14 @@ export class OauthDataGuard implements CanActivate {
     constructor(private readonly logger: WinstonLoggerService) {}
     async canActivate(context: ExecutionContext): Promise<boolean> {
         const request = context.switchToHttp().getRequest();
+        const oauthData = this.extractOauthDataFromCookies(request);
+
+        request.oauthData = oauthData;
+
+        return true;
+    }
+
+    private extractOauthDataFromCookies(request: any) {
         const oauthAccessToken = request.cookies['oauthAccessToken'];
         const oauthRefreshToken = request.cookies['oauthRefreshToken'];
         const provider = request.cookies['provider'];
@@ -24,8 +32,7 @@ export class OauthDataGuard implements CanActivate {
             this.logger.error(`OAuthDataGuard failed: missing ${missingFields}.`, { trace: error.stack ?? 'No stack' });
             throw error;
         }
-        request.oauthData = { oauthAccessToken, oauthRefreshToken, provider };
 
-        return true;
+        return { oauthAccessToken, oauthRefreshToken, provider };
     }
 }

--- a/backend/src/dogs/guards/auth-dog.guard.ts
+++ b/backend/src/dogs/guards/auth-dog.guard.ts
@@ -1,4 +1,4 @@
-import { CanActivate, ExecutionContext, ForbiddenException, Injectable } from '@nestjs/common';
+import { BadRequestException, CanActivate, ExecutionContext, ForbiddenException, Injectable } from '@nestjs/common';
 
 import { WinstonLoggerService } from '../../common/logger/winstonLogger.service';
 import { UsersService } from '../../users/users.service';
@@ -13,8 +13,28 @@ export class AuthDogGuard implements CanActivate {
     async canActivate(context: ExecutionContext): Promise<boolean> {
         const request = context.switchToHttp().getRequest();
         const { userId } = request.user;
-        const dogId = parseInt(request.params.id);
+        const dogId = this.getDogId(request);
 
+        await this.checkDogOwnership(userId, dogId);
+
+        return true;
+    }
+
+    private getDogId(request: any): number {
+        const id = request.query.dogId || request.params.id;
+
+        if (!this.isInt(id)) {
+            const error = new BadRequestException('Invalid dogId.');
+            this.logger.error('Invalid dogId.', {
+                trace: error.stack ?? 'No stack',
+            });
+            throw error;
+        }
+
+        return parseInt(id);
+    }
+
+    private async checkDogOwnership(userId: number, dogId: number): Promise<void> {
         const [owned] = await this.usersService.checkDogOwnership(userId, dogId);
 
         if (!owned) {
@@ -22,7 +42,10 @@ export class AuthDogGuard implements CanActivate {
             this.logger.error(`User ${userId} does not own the dog ${dogId}.`, { trace: error.stack ?? 'No stack' });
             throw error;
         }
+    }
 
-        return true;
+    private isInt(value: any): boolean {
+        const regex = /^\d+$/;
+        return regex.test(value);
     }
 }

--- a/backend/src/journals/guards/auth-journal.guard.ts
+++ b/backend/src/journals/guards/auth-journal.guard.ts
@@ -15,6 +15,12 @@ export class AuthJournalGuard implements CanActivate {
         const { userId } = request.user;
         const journalId = parseInt(request.params.id);
 
+        await this.checkJournalOwnership(userId, journalId);
+
+        return true;
+    }
+
+    private async checkJournalOwnership(userId: number, journalId: number): Promise<void> {
         const [owned] = await this.journalsService.checkJournalOwnership(userId, journalId);
 
         if (!owned) {
@@ -24,7 +30,5 @@ export class AuthJournalGuard implements CanActivate {
             });
             throw error;
         }
-
-        return true;
     }
 }


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- guard 가독성 향상 및 validation 추가 
  - logic을 method로 분리하여 canActivate의 가독성을 향상시켰다.
  - AuthDogGuard의 경우 dogId의 값을 query나 params에서 가져올 때 validation 추가했다. dogId의 값을 params에서 가져올 때에는 controller의 url에서 regex로 검증되지만 query에서 가져올 때에는 따로 validation이 필요하기 때문이다.
  - AuthService의 validateAccessToken과 validateRefreshToken에서 token verify까지 진행하도록 수정했다.
- 바뀐 method logic에 맞게 test code 수정
  - Guard를 수정하면서 AuthService의 validateAccess/RefreshToken method가 변경되어 이에 맞게 test code를 수정했다.

## 링크 (Links)
https://www.notion.so/do0ori/Guard-refactoring-9d155038ed1745b38af6e368ee0b45bb

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
