### PR TITLE
frontend/DANG-1025: cookie에 refreshtoken 없을때 로그아웃 되지 않는 문제 해결

### DIFF
--- a/frontend/src/pages/Join/index.tsx
+++ b/frontend/src/pages/Join/index.tsx
@@ -134,7 +134,7 @@ export default function SignUp() {
         }
         if (step === 'DogDetailInfo') {
             spinnerAdd();
-            const urlData = await getUploadUrl(['png']);
+            const urlData = await getUploadUrl(['jpeg']);
             const fileName = urlData[0]?.filename;
             const photoUrl = urlData[0]?.url;
 


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
storage에 isSignedIn이 true인 상태에서 refreshToken이 cookie에 없는경우 로그인 상태로 있을때 
interceptor에서 비로그인화 상태로 만들기 
## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
