### PR TITLE
frontend/DANG-1033: LoginAlertModal 로그인 상태관련 로직 수정

### DIFF
--- a/frontend/src/components/NavbarProvider.tsx
+++ b/frontend/src/components/NavbarProvider.tsx
@@ -3,13 +3,13 @@ import Navbar from '@/components/Navbar';
 import OAuthButton from '@/components/OAuthButton';
 import BottomSheet from '@/components/commons/BottomSheet';
 import { OAUTH } from '@/constants';
-import { useAuthStore } from '@/store/authStore';
+import { useAuth } from '@/hooks/useAuth';
 import React, { useState } from 'react';
 interface Props {
     children: React.ReactNode;
 }
 export default function NavbarProvider({ children }: Props) {
-    const { isSignedIn } = useAuthStore();
+    const { refreshTokenQuery } = useAuth();
     const [isLoginBottomSheetOpen, setLoginBottomSheetState] = useState(false);
     const handleClose = () => {
         setLoginBottomSheetState(false);
@@ -21,7 +21,7 @@ export default function NavbarProvider({ children }: Props) {
         <>
             {children}
             <Navbar />
-            {!isSignedIn && !isLoginBottomSheetOpen && (
+            {!refreshTokenQuery.isSuccess && !refreshTokenQuery.isLoading && !isLoginBottomSheetOpen && (
                 <LoginAlertModal isOpen={isLoginBottomSheetOpen} setToggle={handleToggle} />
             )}
             <BottomSheet isOpen={isLoginBottomSheetOpen} onClose={handleClose}>

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -56,7 +56,7 @@ const useSignUp = (mutationOptions?: UseMutationCustomOptions) => {
 
 const useGetRefreshToken = () => {
     const { storeSignIn, isSignedIn } = useAuthStore();
-    const { isSuccess, data } = useQuery({
+    const { isSuccess, data, isLoading } = useQuery({
         queryKey: [queryKeys.GET_ACCESS_TOKEN],
         queryFn: refreshAccessToken,
         gcTime: ONE_HOUR,
@@ -72,7 +72,7 @@ const useGetRefreshToken = () => {
         }
     }, [isSuccess, data]);
 
-    return { isSuccess, data };
+    return { isSuccess, data, isLoading };
 };
 
 const useSignOut = (mutationOptions?: UseMutationCustomOptions) => {


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
LoginAlertModal에서 localStorage에 isSignedIn 상태를 확인해서 렌더링 했었는데,
refreshTokenQuery.isSuccess 유무로 판단하는 걸로 수정
새로고침했을때 modal 잠깐 렌더링 되는 것도 !refreshTokenQuery.isLoading 조건을 주어서 렌더링 안되게 수정
## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
