### PR TITLE
backend/DANG-1038: 산책 일지 생성 및 삭제 시 DogWalkDay까지 확인하도록 e2e test 수정

### DIFF
--- a/backend/test/journals.e2e-spec.ts
+++ b/backend/test/journals.e2e-spec.ts
@@ -18,6 +18,7 @@ import {
     testUnauthorizedAccess,
 } from './test-utils';
 
+import { DogWalkDay } from '../src/dog-walk-day/dog-walk-day.entity';
 import { Excrements } from '../src/excrements/excrements.entity';
 import { createMockJournal, mockJournalProfile } from '../src/fixtures/journals.fixture';
 import { mockJournals } from '../src/fixtures/statistics.fixture';
@@ -181,11 +182,40 @@ describe('JournalsController (e2e)', () => {
                     .send(createMockJournal)
                     .expect(201);
 
-                expect(await dataSource.getRepository(Journals).count({})).toBe(1);
+                expect(await dataSource.getRepository(Journals).count()).toBe(1);
                 expect(await dataSource.getRepository(JournalsDogs).count()).toBe(2);
                 expect(await dataSource.getRepository(JournalPhotos).count()).toBe(2);
                 expect(await dataSource.getRepository(Excrements).count({ where: { dogId: 1 } })).toBe(2);
                 expect(await dataSource.getRepository(Excrements).count({ where: { dogId: 2 } })).toBe(1);
+
+                const today = new Date();
+                const dayOfWeek = today.getDay();
+                const days = ['sun', 'mon', 'tue', 'wed', 'thr', 'fri', 'sat'];
+                const todayString = days[dayOfWeek];
+
+                const dog1WalkDay = await dataSource
+                    .getRepository(DogWalkDay)
+                    .findOne({ where: { id: 1 }, select: days });
+                if (!dog1WalkDay) throw new Error('dog1WalkDay not found');
+
+                const dog2WalkDay = await dataSource
+                    .getRepository(DogWalkDay)
+                    .findOne({ where: { id: 2 }, select: days });
+                if (!dog2WalkDay) throw new Error('dog2WalkDay not found');
+
+                const expectedWalkDays = {
+                    mon: 0,
+                    tue: 0,
+                    wed: 0,
+                    thr: 0,
+                    fri: 0,
+                    sat: 0,
+                    sun: 0,
+                    [todayString]: 1,
+                };
+
+                expect(dog1WalkDay).toEqual(expectedWalkDays);
+                expect(dog2WalkDay).toEqual(expectedWalkDays);
             });
         });
 
@@ -317,6 +347,31 @@ describe('JournalsController (e2e)', () => {
                     .expect(204);
 
                 expect(await dataSource.getRepository(Journals).count()).toBe(0);
+
+                const days = ['sun', 'mon', 'tue', 'wed', 'thr', 'fri', 'sat'];
+
+                const dog1WalkDay = await dataSource
+                    .getRepository(DogWalkDay)
+                    .findOne({ where: { id: 1 }, select: days });
+                if (!dog1WalkDay) throw new Error('dog1WalkDay not found');
+
+                const dog2WalkDay = await dataSource
+                    .getRepository(DogWalkDay)
+                    .findOne({ where: { id: 2 }, select: days });
+                if (!dog2WalkDay) throw new Error('dog2WalkDay not found');
+
+                const expectedWalkDays = {
+                    mon: 0,
+                    tue: 0,
+                    wed: 0,
+                    thr: 0,
+                    fri: 0,
+                    sat: 0,
+                    sun: 0,
+                };
+
+                expect(dog1WalkDay).toEqual(expectedWalkDays);
+                expect(dog2WalkDay).toEqual(expectedWalkDays);
             });
         });
 

--- a/backend/test/test-utils.ts
+++ b/backend/test/test-utils.ts
@@ -4,7 +4,7 @@ import { getDataSourceToken } from '@nestjs/typeorm';
 import * as cookieParser from 'cookie-parser';
 import * as request from 'supertest';
 import { AllMethods } from 'supertest/types';
-import { DataSource } from 'typeorm';
+import { DataSource, In } from 'typeorm';
 import { initializeTransactionalContext } from 'typeorm-transactional';
 
 import { AppModule } from './../src/app.module';
@@ -152,11 +152,13 @@ export const insertMockJournal = async () => {
     await dataSource.getRepository(JournalsDogs).save(mockJournalDogs);
     await dataSource.getRepository(JournalPhotos).save(mockJournalPhotos);
     await dataSource.getRepository(Excrements).save(mockExcrements);
+    await dataSource.getRepository(DogWalkDay).update({ id: In([1, 2]) }, { wed: 1 });
     await dataSource.query('SET FOREIGN_KEY_CHECKS = 1;');
 };
 
 export const clearJournal = async () => {
     await dataSource.query('SET FOREIGN_KEY_CHECKS = 0;');
+    await dataSource.getRepository(DogWalkDay).update({ id: In([1, 2]) }, { wed: 0 });
     await dataSource.getRepository(Excrements).clear();
     await dataSource.getRepository(JournalPhotos).clear();
     await dataSource.getRepository(JournalsDogs).clear();


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- 산책 일지 생성 테스트의 오타를 수정했다.
- 산책 일지 생성 및 삭제 시 DogWalkDay가 업데이트되므로 검증 코드를 추가했다.
- 이에 맞게 test-utils에서 mockJournal 생성 및 삭제 함수에서도 DogWalkDay를 추가했다.

## 링크 (Links)
https://www.notion.so/do0ori/JournalsController-e2e-test-DogWalkDay-bba23daa3f7847b1a6261df46599882b

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
