### PR TITLE
backend/DANG-1057: FakeDate을 설정해 산책 일지 삭제 요청 시 walkDay 검증이 실패하는 오류 수정

### DIFF
--- a/backend/test/journals.e2e-spec.ts
+++ b/backend/test/journals.e2e-spec.ts
@@ -6,6 +6,7 @@ import { VALID_ACCESS_TOKEN_100_YEARS } from './constants';
 
 import {
     clearDogs,
+    clearFakeDate,
     clearJournal,
     clearJournals,
     clearUsers,
@@ -14,6 +15,7 @@ import {
     insertMockJournal,
     insertMockJournals,
     insertMockUser,
+    setFakeDate,
     setupTestApp,
     testUnauthorizedAccess,
 } from './test-utils';
@@ -333,9 +335,12 @@ describe('JournalsController (e2e)', () => {
             beforeEach(async () => {
                 await insertMockDogs();
                 await insertMockJournal();
+                const fakeDate = new Date('2024-06-12T00:00:00Z');
+                setFakeDate(fakeDate);
             });
 
             afterEach(async () => {
+                clearFakeDate();
                 await clearJournal();
                 await clearDogs();
             });


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->

## 링크 (Links)
https://www.notion.so/do0ori/e2e-test-case-fe947917c946454fa4e2f1d15c9fcd87

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
