### PR TITLE
backend/DANG-1063: TokenService method를 비동기 함수로 수정 및 AuthService TODO 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img src="https://github.com/jihwooon/dangdang-walk/assets/71831926/eb7dcd0a-7808-4597-9b8c-b8bd962e0868" alt="dangdangwalk-logo">
 </p>
 
-<p align="center"> 견주와 반려견이 함께 산책을 통해 건강을 관리하자 “DangDangWalk App” ​입니다. <p/>
+<p align="center"> 견주와 반려견이 함께 산책을 통해 건강을 관리할 수 있는 "DangDangWalk App"​입니다. </p>
 <br><br>
 
 # 🎯 프로젝트 소개

--- a/backend/src/auth/token/token.service.ts
+++ b/backend/src/auth/token/token.service.ts
@@ -40,34 +40,34 @@ export class TokenService {
         };
     }
 
-    signAccessToken(userId: number, provider: OauthProvider) {
+    async signAccessToken(userId: number, provider: OauthProvider) {
         const payload: AccessTokenPayload = {
             userId,
             provider,
         };
 
-        const newToken = this.jwtService.sign(payload, {
+        const newToken = await this.jwtService.signAsync(payload, {
             expiresIn: TokenService.TOKEN_LIFETIME_MAP.access.expiresIn,
         });
 
         return newToken;
     }
 
-    signRefreshToken(oauthId: string, provider: OauthProvider) {
+    async signRefreshToken(oauthId: string, provider: OauthProvider) {
         const payload: RefreshTokenPayload = {
             oauthId,
             provider,
         };
 
-        const newToken = this.jwtService.sign(payload, {
+        const newToken = await this.jwtService.signAsync(payload, {
             expiresIn: TokenService.TOKEN_LIFETIME_MAP.refresh.expiresIn,
         });
 
         return newToken;
     }
 
-    verify(token: string): AccessTokenPayload | RefreshTokenPayload {
-        const payload = this.jwtService.verify(token, {
+    async verify(token: string): Promise<AccessTokenPayload | RefreshTokenPayload> {
+        const payload = await this.jwtService.verifyAsync(token, {
             ignoreExpiration: false,
         });
 


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- 추후 병렬 처리를 하기 위해 TokenService method를 비동기 함수로 변경
- 불필요한 전역 변수 제거
- TokenService method들을 병렬 처리를 위해 비동기 함수로 변경했으므로 await 추가
- TODO 추가
  - batch query
  - `Promise.all`로 병렬 처리

## 링크 (Links)
https://www.notion.so/do0ori/AuthService-TODO-236be76c60534b16b3a6b987c17b1893

## 기타 사항 (Etc)
왜인지 오늘 같이 추가한 auth TODO가 누락되어서 따로 확인해서 추가함

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
