### PR TITLE
frontend/DANG-1068: 최초가입후 강아지 등록 후 callback 페이지로 리다이렉트 되는 문제 해결

### DIFF
--- a/frontend/src/hooks/useDog.ts
+++ b/frontend/src/hooks/useDog.ts
@@ -3,19 +3,16 @@ import queryClient from '@/api/queryClient';
 import { uploadImage } from '@/api/upload';
 import { UseMutationCustomOptions } from '@/types/common';
 import { useMutation, useQuery } from '@tanstack/react-query';
-import { useNavigate } from 'react-router-dom';
 import { FIFTY_MIN, ONE_HOUR, queryKeys } from '@/constants';
 import { useAuthStore } from '@/store/authStore';
 import { Dog } from '@/models/dog';
 
 const useCreateDog = (mutationOptions?: UseMutationCustomOptions) => {
-    const navigate = useNavigate();
     return useMutation({
         mutationFn: createDog,
         ...mutationOptions,
         onSuccess: async () => {
             queryClient.invalidateQueries({ queryKey: [queryKeys.DOGS] });
-            navigate(-1);
         },
     });
 };

--- a/frontend/src/hooks/useDogsStatistic.ts
+++ b/frontend/src/hooks/useDogsStatistic.ts
@@ -26,7 +26,7 @@ const MINUTE = 1000 * 60;
 const useDogsStatistic = () => {
     const { isSignedIn } = useAuthStore();
     const { data, isPending } = useQuery({
-        queryKey: [queryKeys.DOG_STATISTICS],
+        queryKey: [queryKeys.DOGS, queryKeys.DOG_STATISTICS],
         queryFn: fetchDogStatistic,
         staleTime: MINUTE,
     });

--- a/frontend/src/pages/Join/index.tsx
+++ b/frontend/src/pages/Join/index.tsx
@@ -144,6 +144,7 @@ export default function SignUp() {
                       createDog.mutate({ ...registerData, profilePhotoUrl: fileName });
                   });
             spinnerRemove();
+            currentPage ? navigate(-1) : navigate('/');
         }
 
         switch (step) {


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
최초가입후 강아지 등록 후 callback 페이지로 리다이렉트 되는 문제 해결
## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
