### PR TITLE
frontend/DANG-1069: 일지 상세 페이지에서 읽기 모드일 때 메모 포커스 없애기

### DIFF
--- a/frontend/src/components/journals/MemoSection.tsx
+++ b/frontend/src/components/journals/MemoSection.tsx
@@ -1,7 +1,7 @@
 import Heading from '@/components/journals/Heading';
 import { RefObject } from 'react';
 
-export default function MemoSection({ textAreaRef, readonly = false }: Props) {
+export default function MemoSection({ textAreaRef, disabled = false }: Props) {
     return (
         <div className="px-5 py-[10px]">
             <Heading headingNumber={2}>메모</Heading>
@@ -9,7 +9,7 @@ export default function MemoSection({ textAreaRef, readonly = false }: Props) {
                 name="memo"
                 className="my-2 h-[100px] w-full rounded-lg border border-[#E4E4E4] px-4 py-3 text-xs placeholder:text-[#BABABA]"
                 placeholder="오늘 산책에 대해서 자유롭게 메모해보세요."
-                readOnly={readonly}
+                disabled={disabled}
                 ref={textAreaRef}
             />
         </div>
@@ -18,5 +18,5 @@ export default function MemoSection({ textAreaRef, readonly = false }: Props) {
 
 interface Props {
     textAreaRef: RefObject<HTMLTextAreaElement>;
-    readonly?: boolean;
+    disabled?: boolean;
 }

--- a/frontend/src/pages/Journals/Detail.tsx
+++ b/frontend/src/pages/Journals/Detail.tsx
@@ -120,7 +120,7 @@ export default function Detail() {
                         onDeleteImage={handleDeleteImage}
                     />
                     <Divider />
-                    <MemoSection textAreaRef={textAreaRef} readonly={!isModifying} />
+                    <MemoSection textAreaRef={textAreaRef} disabled={!isModifying} />
                 </div>
                 {isModifying ? (
                     <Button rounded="none" className="h-16 w-full" disabled={isSaving} onClick={handleSave}>


### PR DESCRIPTION
## 작업 내용 (Content)
일지 상세 페이지에서 읽기 모드일 때 메모 포커스 없애기

## 링크 (Links)
https://www.notion.so/do0ori/fd93343842a44f05ba88efb419705342?pvs=4

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
