### PR TITLE
backend/DANG-1083: status code 200->204로 변경된 api swagger에 반영

### DIFF
--- a/docs/auth/users.yaml
+++ b/docs/auth/users.yaml
@@ -64,7 +64,7 @@ patch:
               type: string
               description: 사용자 프로필 이미지 url
   responses:
-    "200":
+    "204":
       description: 회원 정보가 정상적으로 수정된 경우
     "401":
       description: Authorization header가 없거나 유효한 access token이 아닌 경우

--- a/docs/images/delete.yaml
+++ b/docs/images/delete.yaml
@@ -20,13 +20,8 @@ delete:
             description: 업로드할 파일의 확장자
             example: "jpg"
   responses:
-    "200":
+    "204":
       description: 이미지 삭제 성공
-      content:
-        text/plain:
-          schema:
-            type: boolean
-            example: true
     "401":
       description: Authorization header가 없거나 유효한 access token이 아닌 경우
     "403":

--- a/docs/journals/id.yaml
+++ b/docs/journals/id.yaml
@@ -26,13 +26,8 @@ patch:
                 description: 산책일지 사진 경로
                 example: "1/randomName.jpg"
   responses:
-    "200":
+    "204":
       description: 산책일지 수정 성공
-      content:
-        text/plain:
-          schema:
-            type: boolean
-            example: true
     "401":
       description: Authorization header가 없거나 유효한 access token이 아닌 경우
     "403":
@@ -53,13 +48,8 @@ delete:
         type: string
         example: "Bearer ${accessToken}"
   responses:
-    "200":
+    "204":
       description: 산책일지 삭제 성공
-      content:
-        text/plain:
-          schema:
-            type: boolean
-            example: true
     "401":
       description: Authorization header가 없거나 유효한 access token이 아닌 경우
     "403":


### PR DESCRIPTION
## 작업 내용 (Content)
#### 히스토리
삭제, 수정 성공시 리턴할 데이터가 없어도 true를 반환했었는데
그럴 필요가 없다고 판단되어 reponse 데이터를 없애고,
status 코드를 200 -> 204(성공했음 & 반환 데이터 없음)로 변경하였고
이를 swagger에도 반영하였습니다.

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
