### PR TITLE
backend/DANG-1095: dogs, s3, users e2e 테스트에서 fixture를 각 테스트에서 정의하도록 변경

### DIFF
--- a/backend/test/dogs.e2e-spec.ts
+++ b/backend/test/dogs.e2e-spec.ts
@@ -71,13 +71,21 @@ describe('DogsController (e2e)', () => {
                 await clearDogs();
             });
 
-            const { id: _id, ...createMockDog } = mockDogProfile;
+            const createDogMock = {
+                name: '덕지',
+                breed: '아펜핀셔',
+                gender: 'MALE',
+                isNeutered: true,
+                birth: null,
+                weight: 2,
+                profilePhotoUrl: 'mock_profile_photo.jpg',
+            };
 
             it('201 상태 코드를 반환해야 한다.', async () => {
                 await request(app.getHttpServer())
                     .post('/dogs')
                     .set('Authorization', `Bearer ${VALID_ACCESS_TOKEN_100_YEARS}`)
-                    .send(createMockDog)
+                    .send(createDogMock)
                     .expect(201);
 
                 expect(await dataSource.getRepository(Dogs).count()).toBe(1);
@@ -93,14 +101,22 @@ describe('DogsController (e2e)', () => {
                 await clearDogs();
             });
 
-            const { id: _id, ...createMockDog } = mockDogProfile;
-            createMockDog.breed = '시고르자브종';
+            const createDogMock = {
+                name: '덕지',
+                breed: '아펜핀셔',
+                gender: 'MALE',
+                isNeutered: true,
+                birth: null,
+                weight: 2,
+                profilePhotoUrl: 'mock_profile_photo.jpg',
+            };
+            createDogMock.breed = '시고르자브종';
 
             it('404 상태 코드를 반환해야 한다.', () => {
                 return request(app.getHttpServer())
                     .post('/dogs')
                     .set('Authorization', `Bearer ${VALID_ACCESS_TOKEN_100_YEARS}`)
-                    .send(createMockDog)
+                    .send(createDogMock)
                     .expect(404);
             });
         });
@@ -158,19 +174,27 @@ describe('DogsController (e2e)', () => {
                 await clearDogs();
             });
 
-            const { id: _id, ...updateMockDog } = mockDog2Profile;
+            const updateDogMock = {
+                name: '루이',
+                breed: '아프간 하운드',
+                gender: 'FEMALE',
+                isNeutered: false,
+                birth: null,
+                weight: 1,
+                profilePhotoUrl: 'mock_profile_photo2.jpg',
+            };
 
             it('204 상태 코드를 반환해야 한다.', async () => {
                 await request(app.getHttpServer())
                     .patch('/dogs/1')
                     .set('Authorization', `Bearer ${VALID_ACCESS_TOKEN_100_YEARS}`)
-                    .send(updateMockDog)
+                    .send(updateDogMock)
                     .expect(204);
 
                 const updatedDog = await dataSource.getRepository(Dogs).findOne({ where: { id: 1 } });
                 if (!updatedDog) throw new Error('Dog not found');
                 updatedDog.breed = (updatedDog.breed as any).koreanName;
-                expect(updatedDog).toMatchObject(updateMockDog);
+                expect(updatedDog).toMatchObject(updateDogMock);
             });
         });
 
@@ -192,14 +216,22 @@ describe('DogsController (e2e)', () => {
                 await clearDogs();
             });
 
-            const { id: _id, ...updateMockDog } = mockDog2Profile;
-            updateMockDog.breed = '시고르자브종';
+            const updateDogMock = {
+                name: '루이',
+                breed: '아프간 하운드',
+                gender: 'FEMALE',
+                isNeutered: false,
+                birth: null,
+                weight: 1,
+                profilePhotoUrl: 'mock_profile_photo2.jpg',
+            };
+            updateDogMock.breed = '시고르자브종';
 
             it('404 상태 코드를 반환해야 한다.', () => {
                 return request(app.getHttpServer())
                     .patch('/dogs/1')
                     .set('Authorization', `Bearer ${VALID_ACCESS_TOKEN_100_YEARS}`)
-                    .send(updateMockDog)
+                    .send(updateDogMock)
                     .expect(404);
             });
         });

--- a/backend/test/dogs.e2e-spec.ts
+++ b/backend/test/dogs.e2e-spec.ts
@@ -101,22 +101,21 @@ describe('DogsController (e2e)', () => {
                 await clearDogs();
             });
 
-            const createDogMock = {
+            const invalidBreedMock = {
                 name: '덕지',
-                breed: '아펜핀셔',
+                breed: '시고르자브종',
                 gender: 'MALE',
                 isNeutered: true,
                 birth: null,
                 weight: 2,
                 profilePhotoUrl: 'mock_profile_photo.jpg',
             };
-            createDogMock.breed = '시고르자브종';
 
             it('404 상태 코드를 반환해야 한다.', () => {
                 return request(app.getHttpServer())
                     .post('/dogs')
                     .set('Authorization', `Bearer ${VALID_ACCESS_TOKEN_100_YEARS}`)
-                    .send(createDogMock)
+                    .send(invalidBreedMock)
                     .expect(404);
             });
         });
@@ -174,7 +173,7 @@ describe('DogsController (e2e)', () => {
                 await clearDogs();
             });
 
-            const updateDogMock = {
+            const updateData = {
                 name: '루이',
                 breed: '아프간 하운드',
                 gender: 'FEMALE',
@@ -188,13 +187,27 @@ describe('DogsController (e2e)', () => {
                 await request(app.getHttpServer())
                     .patch('/dogs/1')
                     .set('Authorization', `Bearer ${VALID_ACCESS_TOKEN_100_YEARS}`)
-                    .send(updateDogMock)
+                    .send(updateData)
                     .expect(204);
 
                 const updatedDog = await dataSource.getRepository(Dogs).findOne({ where: { id: 1 } });
                 if (!updatedDog) throw new Error('Dog not found');
                 updatedDog.breed = (updatedDog.breed as any).koreanName;
-                expect(updatedDog).toMatchObject(updateDogMock);
+                expect(updatedDog).toEqual({
+                    id: 1,
+                    walkDayId: 1,
+                    todayWalkTimeId: 1,
+                    name: '루이',
+                    breed: '아프간 하운드',
+                    gender: 'FEMALE',
+                    isNeutered: false,
+                    birth: null,
+                    weight: 1,
+                    profilePhotoUrl: 'mock_profile_photo2.jpg',
+                    breedId: 2,
+                    isWalking: false,
+                    updatedAt: expect.any(Date),
+                });
             });
         });
 
@@ -216,22 +229,21 @@ describe('DogsController (e2e)', () => {
                 await clearDogs();
             });
 
-            const updateDogMock = {
+            const invalidDogMock = {
                 name: '루이',
-                breed: '아프간 하운드',
+                breed: '시고르자브종',
                 gender: 'FEMALE',
                 isNeutered: false,
                 birth: null,
                 weight: 1,
                 profilePhotoUrl: 'mock_profile_photo2.jpg',
             };
-            updateDogMock.breed = '시고르자브종';
 
             it('404 상태 코드를 반환해야 한다.', () => {
                 return request(app.getHttpServer())
                     .patch('/dogs/1')
                     .set('Authorization', `Bearer ${VALID_ACCESS_TOKEN_100_YEARS}`)
-                    .send(updateDogMock)
+                    .send(invalidDogMock)
                     .expect(404);
             });
         });

--- a/backend/test/users.e2e-spec.ts
+++ b/backend/test/users.e2e-spec.ts
@@ -2,11 +2,10 @@ import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
 import { DataSource } from 'typeorm';
 
-import { VALID_ACCESS_TOKEN_100_YEARS } from './constants';
+import { VALID_ACCESS_TOKEN_100_YEARS, VALID_PROVIDER_KAKAO } from './constants';
 
 import { clearUsers, closeTestApp, insertMockUser, setupTestApp, testUnauthorizedAccess } from './test-utils';
 
-import { mockUserProfile } from '../src/fixtures/users.fixture';
 import { Users } from '../src/users/users.entity';
 
 describe('UsersController (e2e)', () => {
@@ -31,7 +30,12 @@ describe('UsersController (e2e)', () => {
 
     describe('/users/me (GET)', () => {
         context('사용자가 회원 정보 조회 요청을 보내면', () => {
-            const { id: _id, ...mockUserInfo } = mockUserProfile;
+            const mockUserInfo = {
+                nickname: 'mock_oauth_nickname#12345',
+                email: 'mock_email@example.com',
+                profileImageUrl: 'mock_profile_image.jpg',
+                provider: VALID_PROVIDER_KAKAO,
+            };
 
             it('200 상태 코드와 사용자 정보를 반환해야 한다.', async () => {
                 const response = await request(app.getHttpServer())
@@ -48,7 +52,11 @@ describe('UsersController (e2e)', () => {
 
     describe('/users/me (PATCH)', () => {
         context('사용자가 회원 정보 수정 요청을 보내면', () => {
-            const { id: _id, provider: _provider, ...mockUserInfo } = mockUserProfile;
+            const mockUserInfo = {
+                nickname: 'mock_oauth_nickname#12345',
+                email: 'mock_email@example.com',
+                profileImageUrl: 'mock_profile_image.jpg',
+            };
             const updateMockUser = {
                 nickname: 'new_mock_nickname',
                 profileImageUrl: 'new_mock_profile_image.jpg',


### PR DESCRIPTION
## 작업 내용 (Content)
테스트 간 독립성을 유지하고, 사용되는 mock을 한눈에 볼 수 있게 하기 위해 fixture를 각 테스트에서 정의해 사용하는 방식으로 변경하였습니다.

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
