### PR TITLE
backend/DANG-1093: auth, statistics e2e test 하드코딩

### DIFF
--- a/backend/src/fixtures/users.fixture.ts
+++ b/backend/src/fixtures/users.fixture.ts
@@ -1,9 +1,11 @@
-import { VALID_PROVIDER_KAKAO, VALID_REFRESH_TOKEN_100_YEARS } from '../../test/constants';
+import {
+    OAUTH_ACCESS_TOKEN,
+    OAUTH_REFRESH_TOKEN,
+    VALID_PROVIDER_KAKAO,
+    VALID_REFRESH_TOKEN_100_YEARS,
+} from '../../test/constants';
 import { ROLE } from '../users/types/role.type';
 import { Users } from '../users/users.entity';
-
-export const OAUTH_ACCESS_TOKEN = 'oauth_access_token';
-export const OAUTH_REFRESH_TOKEN = 'oauth_refresh_token';
 
 export const mockUser = new Users({
     id: 1,

--- a/backend/src/users/users.spec.ts
+++ b/backend/src/users/users.spec.ts
@@ -2,8 +2,8 @@ import { ROLE } from './types/role.type';
 
 import { Users } from './users.entity';
 
-import { VALID_REFRESH_TOKEN_100_YEARS } from '../../test/constants';
-import { OAUTH_ACCESS_TOKEN, OAUTH_REFRESH_TOKEN, mockUser } from '../fixtures/users.fixture';
+import { OAUTH_ACCESS_TOKEN, OAUTH_REFRESH_TOKEN, VALID_REFRESH_TOKEN_100_YEARS } from '../../test/constants';
+import { mockUser } from '../fixtures/users.fixture';
 
 describe('User', () => {
     it('user 정보가 주어지면 user 정보를 반환해야 한다.', () => {

--- a/backend/test/constants.ts
+++ b/backend/test/constants.ts
@@ -17,3 +17,7 @@ export const MALFORMED_REFRESH_TOKEN = 'malformed_refresh_token';
 
 export const VALID_PROVIDER_KAKAO = 'kakao';
 export const INVALID_PROVIDER = 'invalid_provider';
+
+export const AUTHORIZE_CODE = 'authorizeCode';
+export const OAUTH_ACCESS_TOKEN = 'oauth_access_token';
+export const OAUTH_REFRESH_TOKEN = 'oauth_refresh_token';

--- a/backend/test/statistics.e2e-spec.ts
+++ b/backend/test/statistics.e2e-spec.ts
@@ -1,6 +1,8 @@
 import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
 
+import { DataSource } from 'typeorm';
+
 import { VALID_ACCESS_TOKEN_100_YEARS } from './constants';
 
 import {
@@ -17,14 +19,14 @@ import {
     testUnauthorizedAccess,
 } from './test-utils';
 
-import { mockDog, mockDog2 } from '../src/fixtures/dogs.fixture';
-import { mockJournals } from '../src/fixtures/statistics.fixture';
+import { Journals } from '../src/journals/journals.entity';
 
 describe('StatisticsController (e2e)', () => {
     let app: INestApplication;
+    let dataSource: DataSource;
 
     beforeAll(async () => {
-        ({ app } = await setupTestApp());
+        ({ app, dataSource } = await setupTestApp());
     });
 
     beforeEach(async () => {
@@ -59,6 +61,8 @@ describe('StatisticsController (e2e)', () => {
                     .get('/dogs/1/statistics/recent?period=month')
                     .set('Authorization', `Bearer ${VALID_ACCESS_TOKEN_100_YEARS}`)
                     .expect(200);
+
+                const mockJournals = await dataSource.getRepository(Journals).find();
 
                 expect(response.body).toEqual({
                     totalWalkCnt: mockJournals.length,
@@ -228,17 +232,17 @@ describe('StatisticsController (e2e)', () => {
 
                 expect(response.body).toEqual([
                     {
-                        id: mockDog.id,
-                        name: mockDog.name,
-                        profilePhotoUrl: mockDog.profilePhotoUrl,
+                        id: 1,
+                        name: '덕지',
+                        profilePhotoUrl: 'mock_profile_photo.jpg',
                         recommendedWalkAmount: 1800,
                         todayWalkAmount: 0,
                         weeklyWalks: [0, 0, 0, 0, 0, 0, 0],
                     },
                     {
-                        id: mockDog2.id,
-                        name: mockDog2.name,
-                        profilePhotoUrl: mockDog2.profilePhotoUrl,
+                        id: 2,
+                        name: '루이',
+                        profilePhotoUrl: 'mock_profile_photo2.jpg',
                         recommendedWalkAmount: 7200,
                         todayWalkAmount: 0,
                         weeklyWalks: [0, 0, 0, 0, 0, 0, 0],


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- 하나의 파일에서 상수들을 관리하기 위해 `users.fixture.ts`에 정의된 상수를 `constants.ts`로 옮겼다.
- fixture 파일에 의존하지 않기 위해 객체를 하드코딩하여 명시 
- database로 정확히 동작을 검증

## 링크 (Links)
https://www.notion.so/do0ori/auth-statistics-e2e-test-f23467a7febc4500b1be844bfe72acdb

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
