### PR TITLE
backend/DANG-1096: test-utils insert method 형식 변경

### DIFF
--- a/backend/test/auth.e2e-spec.ts
+++ b/backend/test/auth.e2e-spec.ts
@@ -14,7 +14,7 @@ import {
     VALID_REFRESH_TOKEN_100_YEARS,
 } from './constants';
 
-import { clearUsers, closeTestApp, insertMockUser, setupTestApp, testUnauthorizedAccess } from './test-utils';
+import { clearUsers, closeTestApp, insertMockUsers, setupTestApp, testUnauthorizedAccess } from './test-utils';
 
 import { ROLE } from '../src/users/types/role.type';
 import { Users } from '../src/users/users.entity';
@@ -50,7 +50,7 @@ describe('AuthController (e2e)', () => {
 
         context('회원이 로그인 요청을 보내면', () => {
             beforeEach(async () => {
-                await insertMockUser();
+                await insertMockUsers();
             });
 
             afterEach(async () => {
@@ -146,7 +146,7 @@ describe('AuthController (e2e)', () => {
 
         context('회원이 회원가입 요청을 보내면', () => {
             beforeEach(async () => {
-                await insertMockUser();
+                await insertMockUsers();
             });
 
             afterEach(async () => {
@@ -212,7 +212,7 @@ describe('AuthController (e2e)', () => {
     describe('/auth/logout (POST)', () => {
         context('회원이 유효한 access token을 Authorization header에 담아 로그아웃 요청을 보내면', () => {
             beforeEach(async () => {
-                await insertMockUser();
+                await insertMockUsers();
             });
 
             afterEach(async () => {
@@ -234,7 +234,7 @@ describe('AuthController (e2e)', () => {
     describe('/auth/token (GET)', () => {
         context('회원이 유효한 refresh token을 cookie에 가지고 token 재발급 요청을 보내면', () => {
             beforeEach(async () => {
-                await insertMockUser();
+                await insertMockUsers();
             });
 
             afterEach(async () => {
@@ -289,7 +289,7 @@ describe('AuthController (e2e)', () => {
     describe('/auth/deactivate (DELETE)', () => {
         context('회원이 유효한 access token을 Authorization header에 담아 회원탈퇴 요청을 보내면', () => {
             beforeEach(async () => {
-                await insertMockUser();
+                await insertMockUsers();
             });
 
             afterEach(async () => {

--- a/backend/test/dogs.e2e-spec.ts
+++ b/backend/test/dogs.e2e-spec.ts
@@ -9,7 +9,7 @@ import {
     clearUsers,
     closeTestApp,
     insertMockDogs,
-    insertMockUser,
+    insertMockUsers,
     setupTestApp,
     testUnauthorizedAccess,
 } from './test-utils';
@@ -23,7 +23,7 @@ describe('DogsController (e2e)', () => {
 
     beforeAll(async () => {
         ({ app, dataSource } = await setupTestApp());
-        await insertMockUser();
+        await insertMockUsers();
     });
 
     afterAll(async () => {

--- a/backend/test/journals.e2e-spec.ts
+++ b/backend/test/journals.e2e-spec.ts
@@ -12,9 +12,9 @@ import {
     clearUsers,
     closeTestApp,
     insertMockDogs,
-    insertMockJournal,
+    insertMockJournalWithPhotosAndExcrements,
     insertMockJournals,
-    insertMockUser,
+    insertMockUsers,
     setFakeDate,
     setupTestApp,
     testUnauthorizedAccess,
@@ -34,7 +34,7 @@ describe('JournalsController (e2e)', () => {
 
     beforeAll(async () => {
         ({ app, dataSource } = await setupTestApp());
-        await insertMockUser();
+        await insertMockUsers();
     });
 
     afterAll(async () => {
@@ -242,7 +242,7 @@ describe('JournalsController (e2e)', () => {
         context('사용자가 자신이 소유한 산책 일지의 상세 요청을 보내면', () => {
             beforeEach(async () => {
                 await insertMockDogs();
-                await insertMockJournal();
+                await insertMockJournalWithPhotosAndExcrements();
             });
 
             afterEach(async () => {
@@ -284,7 +284,7 @@ describe('JournalsController (e2e)', () => {
         context('사용자가 자신이 소유한 산책 일지의 정보 수정 요청을 보내면', () => {
             beforeEach(async () => {
                 await insertMockDogs();
-                await insertMockJournal();
+                await insertMockJournalWithPhotosAndExcrements();
             });
 
             afterEach(async () => {
@@ -334,7 +334,7 @@ describe('JournalsController (e2e)', () => {
         context('사용자가 자신이 소유한 산책 일지의 삭제 요청을 보내면', () => {
             beforeEach(async () => {
                 await insertMockDogs();
-                await insertMockJournal();
+                await insertMockJournalWithPhotosAndExcrements();
                 const fakeDate = new Date('2024-06-12T00:00:00Z');
                 setFakeDate(fakeDate);
             });

--- a/backend/test/s3.e2e-spec.ts
+++ b/backend/test/s3.e2e-spec.ts
@@ -2,7 +2,7 @@ import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
 
 import { VALID_ACCESS_TOKEN_100_YEARS } from './constants';
-import { clearUsers, closeTestApp, insertMockUser, setupTestApp, testUnauthorizedAccess } from './test-utils';
+import { clearUsers, closeTestApp, insertMockUsers, setupTestApp, testUnauthorizedAccess } from './test-utils';
 
 const context = describe;
 
@@ -11,7 +11,7 @@ describe('S3Controller (e2e)', () => {
 
     beforeAll(async () => {
         ({ app } = await setupTestApp());
-        await insertMockUser();
+        await insertMockUsers();
     });
 
     afterAll(async () => {

--- a/backend/test/statistics.e2e-spec.ts
+++ b/backend/test/statistics.e2e-spec.ts
@@ -13,7 +13,7 @@ import {
     closeTestApp,
     insertMockDogs,
     insertMockJournals,
-    insertMockUser,
+    insertMockUsers,
     setFakeDate,
     setupTestApp,
     testUnauthorizedAccess,
@@ -30,7 +30,7 @@ describe('StatisticsController (e2e)', () => {
     });
 
     beforeEach(async () => {
-        await insertMockUser();
+        await insertMockUsers();
         await insertMockDogs();
         await insertMockJournals();
     });

--- a/backend/test/users.e2e-spec.ts
+++ b/backend/test/users.e2e-spec.ts
@@ -4,7 +4,7 @@ import { DataSource } from 'typeorm';
 
 import { VALID_ACCESS_TOKEN_100_YEARS, VALID_PROVIDER_KAKAO } from './constants';
 
-import { clearUsers, closeTestApp, insertMockUser, setupTestApp, testUnauthorizedAccess } from './test-utils';
+import { clearUsers, closeTestApp, insertMockUsers, setupTestApp, testUnauthorizedAccess } from './test-utils';
 
 import { Users } from '../src/users/users.entity';
 
@@ -17,7 +17,7 @@ describe('UsersController (e2e)', () => {
     });
 
     beforeEach(async () => {
-        await insertMockUser();
+        await insertMockUsers();
     });
 
     afterEach(async () => {

--- a/backend/test/walk.e2e-spec.ts
+++ b/backend/test/walk.e2e-spec.ts
@@ -7,7 +7,7 @@ import {
     clearUsers,
     closeTestApp,
     insertMockDogs,
-    insertMockUser,
+    insertMockUsers,
     setupTestApp,
     testUnauthorizedAccess,
 } from './test-utils';
@@ -22,7 +22,7 @@ describe('WalkController (e2e)', () => {
     });
 
     beforeEach(async () => {
-        await insertMockUser();
+        await insertMockUsers();
         await insertMockDogs();
     });
 


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- 고정된 mock data를 삽입하는 대신 parameter를 만들어 원하는 data를 삽입할 수 있도록 수정
- e2e test 코드에서 직접 값을 parameter로 넘겨주므로 가독성 향상 가능

## 링크 (Links)
https://www.notion.so/do0ori/test-utils-insert-method-2ad7b523a5b04d248dea872b8074ed4c

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
