### PR TITLE
backend/DANG-1100: 변경된 test-utils insert method 형식에 따라 e2e test 수정

### DIFF
--- a/backend/test/auth.e2e-spec.ts
+++ b/backend/test/auth.e2e-spec.ts
@@ -50,7 +50,21 @@ describe('AuthController (e2e)', () => {
 
         context('회원이 로그인 요청을 보내면', () => {
             beforeEach(async () => {
-                await insertMockUsers();
+                await insertMockUsers({
+                    mockUsers: new Users({
+                        id: 1,
+                        nickname: 'mock_oauth_nickname#12345',
+                        email: 'mock_email@example.com',
+                        profileImageUrl: 'mock_profile_image.jpg',
+                        role: ROLE.User,
+                        mainDogId: null,
+                        oauthId: '12345',
+                        oauthAccessToken: OAUTH_ACCESS_TOKEN,
+                        oauthRefreshToken: OAUTH_REFRESH_TOKEN,
+                        refreshToken: VALID_REFRESH_TOKEN_100_YEARS,
+                        createdAt: new Date('2019-01-01'),
+                    }),
+                });
             });
 
             afterEach(async () => {
@@ -146,7 +160,21 @@ describe('AuthController (e2e)', () => {
 
         context('회원이 회원가입 요청을 보내면', () => {
             beforeEach(async () => {
-                await insertMockUsers();
+                await insertMockUsers({
+                    mockUsers: new Users({
+                        id: 1,
+                        nickname: 'mock_oauth_nickname#12345',
+                        email: 'mock_email@example.com',
+                        profileImageUrl: 'mock_profile_image.jpg',
+                        role: ROLE.User,
+                        mainDogId: null,
+                        oauthId: '12345',
+                        oauthAccessToken: OAUTH_ACCESS_TOKEN,
+                        oauthRefreshToken: OAUTH_REFRESH_TOKEN,
+                        refreshToken: VALID_REFRESH_TOKEN_100_YEARS,
+                        createdAt: new Date('2019-01-01'),
+                    }),
+                });
             });
 
             afterEach(async () => {
@@ -212,7 +240,21 @@ describe('AuthController (e2e)', () => {
     describe('/auth/logout (POST)', () => {
         context('회원이 유효한 access token을 Authorization header에 담아 로그아웃 요청을 보내면', () => {
             beforeEach(async () => {
-                await insertMockUsers();
+                await insertMockUsers({
+                    mockUsers: new Users({
+                        id: 1,
+                        nickname: 'mock_oauth_nickname#12345',
+                        email: 'mock_email@example.com',
+                        profileImageUrl: 'mock_profile_image.jpg',
+                        role: ROLE.User,
+                        mainDogId: null,
+                        oauthId: '12345',
+                        oauthAccessToken: OAUTH_ACCESS_TOKEN,
+                        oauthRefreshToken: OAUTH_REFRESH_TOKEN,
+                        refreshToken: VALID_REFRESH_TOKEN_100_YEARS,
+                        createdAt: new Date('2019-01-01'),
+                    }),
+                });
             });
 
             afterEach(async () => {
@@ -234,7 +276,21 @@ describe('AuthController (e2e)', () => {
     describe('/auth/token (GET)', () => {
         context('회원이 유효한 refresh token을 cookie에 가지고 token 재발급 요청을 보내면', () => {
             beforeEach(async () => {
-                await insertMockUsers();
+                await insertMockUsers({
+                    mockUsers: new Users({
+                        id: 1,
+                        nickname: 'mock_oauth_nickname#12345',
+                        email: 'mock_email@example.com',
+                        profileImageUrl: 'mock_profile_image.jpg',
+                        role: ROLE.User,
+                        mainDogId: null,
+                        oauthId: '12345',
+                        oauthAccessToken: OAUTH_ACCESS_TOKEN,
+                        oauthRefreshToken: OAUTH_REFRESH_TOKEN,
+                        refreshToken: VALID_REFRESH_TOKEN_100_YEARS,
+                        createdAt: new Date('2019-01-01'),
+                    }),
+                });
             });
 
             afterEach(async () => {
@@ -289,7 +345,21 @@ describe('AuthController (e2e)', () => {
     describe('/auth/deactivate (DELETE)', () => {
         context('회원이 유효한 access token을 Authorization header에 담아 회원탈퇴 요청을 보내면', () => {
             beforeEach(async () => {
-                await insertMockUsers();
+                await insertMockUsers({
+                    mockUsers: new Users({
+                        id: 1,
+                        nickname: 'mock_oauth_nickname#12345',
+                        email: 'mock_email@example.com',
+                        profileImageUrl: 'mock_profile_image.jpg',
+                        role: ROLE.User,
+                        mainDogId: null,
+                        oauthId: '12345',
+                        oauthAccessToken: OAUTH_ACCESS_TOKEN,
+                        oauthRefreshToken: OAUTH_REFRESH_TOKEN,
+                        refreshToken: VALID_REFRESH_TOKEN_100_YEARS,
+                        createdAt: new Date('2019-01-01'),
+                    }),
+                });
             });
 
             afterEach(async () => {

--- a/backend/test/s3.e2e-spec.ts
+++ b/backend/test/s3.e2e-spec.ts
@@ -1,8 +1,17 @@
 import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
 
-import { VALID_ACCESS_TOKEN_100_YEARS } from './constants';
+import {
+    OAUTH_ACCESS_TOKEN,
+    OAUTH_REFRESH_TOKEN,
+    VALID_ACCESS_TOKEN_100_YEARS,
+    VALID_REFRESH_TOKEN_100_YEARS,
+} from './constants';
+
 import { clearUsers, closeTestApp, insertMockUsers, setupTestApp, testUnauthorizedAccess } from './test-utils';
+
+import { ROLE } from '../src/users/types/role.type';
+import { Users } from '../src/users/users.entity';
 
 const context = describe;
 
@@ -11,7 +20,21 @@ describe('S3Controller (e2e)', () => {
 
     beforeAll(async () => {
         ({ app } = await setupTestApp());
-        await insertMockUsers();
+        await insertMockUsers({
+            mockUsers: new Users({
+                id: 1,
+                nickname: 'mock_oauth_nickname#12345',
+                email: 'mock_email@example.com',
+                profileImageUrl: 'mock_profile_image.jpg',
+                role: ROLE.User,
+                mainDogId: null,
+                oauthId: '12345',
+                oauthAccessToken: OAUTH_ACCESS_TOKEN,
+                oauthRefreshToken: OAUTH_REFRESH_TOKEN,
+                refreshToken: VALID_REFRESH_TOKEN_100_YEARS,
+                createdAt: new Date('2019-01-01'),
+            }),
+        });
     });
 
     afterAll(async () => {

--- a/backend/test/test-utils.ts
+++ b/backend/test/test-utils.ts
@@ -18,9 +18,9 @@ import { NaverService } from '../src/auth/oauth/naver.service';
 import { DogWalkDay } from '../src/dog-walk-day/dog-walk-day.entity';
 import { Dogs } from '../src/dogs/dogs.entity';
 import { Excrements } from '../src/excrements/excrements.entity';
+import { Excrement } from '../src/excrements/types/excrement.type';
 import { JournalPhotos } from '../src/journal-photos/journal-photos.entity';
 import { Journals } from '../src/journals/journals.entity';
-import { CreateExcrementsInfo } from '../src/journals/types/create-journal-data.type';
 import { JournalsDogs } from '../src/journals-dogs/journals-dogs.entity';
 import { MockS3Service } from '../src/s3/__mocks__/s3.service';
 import { S3Service } from '../src/s3/s3.service';
@@ -164,11 +164,17 @@ export const clearJournals = async () => {
     await dataSource.query('SET FOREIGN_KEY_CHECKS = 1;');
 };
 
+interface ExcrementData {
+    dogId: number;
+    type: Excrement;
+    coordinate: string;
+}
+
 interface InsertMockJournalWithPhotosAndExcrementsParams {
     mockJournal: Journals;
     dogIds: number | number[];
     photoUrls: string | string[];
-    excrements: CreateExcrementsInfo | CreateExcrementsInfo[];
+    excrements: ExcrementData | ExcrementData[];
 }
 
 // dogIds에게 mockJournal 생성

--- a/backend/test/users.e2e-spec.ts
+++ b/backend/test/users.e2e-spec.ts
@@ -2,10 +2,17 @@ import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
 import { DataSource } from 'typeorm';
 
-import { VALID_ACCESS_TOKEN_100_YEARS, VALID_PROVIDER_KAKAO } from './constants';
+import {
+    OAUTH_ACCESS_TOKEN,
+    OAUTH_REFRESH_TOKEN,
+    VALID_ACCESS_TOKEN_100_YEARS,
+    VALID_PROVIDER_KAKAO,
+    VALID_REFRESH_TOKEN_100_YEARS,
+} from './constants';
 
 import { clearUsers, closeTestApp, insertMockUsers, setupTestApp, testUnauthorizedAccess } from './test-utils';
 
+import { ROLE } from '../src/users/types/role.type';
 import { Users } from '../src/users/users.entity';
 
 describe('UsersController (e2e)', () => {
@@ -17,7 +24,21 @@ describe('UsersController (e2e)', () => {
     });
 
     beforeEach(async () => {
-        await insertMockUsers();
+        await insertMockUsers({
+            mockUsers: new Users({
+                id: 1,
+                nickname: 'mock_oauth_nickname#12345',
+                email: 'mock_email@example.com',
+                profileImageUrl: 'mock_profile_image.jpg',
+                role: ROLE.User,
+                mainDogId: null,
+                oauthId: '12345',
+                oauthAccessToken: OAUTH_ACCESS_TOKEN,
+                oauthRefreshToken: OAUTH_REFRESH_TOKEN,
+                refreshToken: VALID_REFRESH_TOKEN_100_YEARS,
+                createdAt: new Date('2019-01-01'),
+            }),
+        });
     });
 
     afterEach(async () => {

--- a/backend/test/walk.e2e-spec.ts
+++ b/backend/test/walk.e2e-spec.ts
@@ -1,7 +1,13 @@
 import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
 
-import { VALID_ACCESS_TOKEN_100_YEARS } from './constants';
+import {
+    OAUTH_ACCESS_TOKEN,
+    OAUTH_REFRESH_TOKEN,
+    VALID_ACCESS_TOKEN_100_YEARS,
+    VALID_REFRESH_TOKEN_100_YEARS,
+} from './constants';
+
 import {
     clearDogs,
     clearUsers,
@@ -12,6 +18,13 @@ import {
     testUnauthorizedAccess,
 } from './test-utils';
 
+import { DogWalkDay } from '../src/dog-walk-day/dog-walk-day.entity';
+import { Dogs } from '../src/dogs/dogs.entity';
+import { GENDER } from '../src/dogs/types/gender.type';
+import { TodayWalkTime } from '../src/today-walk-time/today-walk-time.entity';
+import { ROLE } from '../src/users/types/role.type';
+import { Users } from '../src/users/users.entity';
+
 describe('WalkController (e2e)', () => {
     let app: INestApplication;
 
@@ -20,8 +33,54 @@ describe('WalkController (e2e)', () => {
     });
 
     beforeEach(async () => {
-        await insertMockUsers();
-        await insertMockDogs();
+        await insertMockUsers({
+            mockUsers: new Users({
+                id: 1,
+                nickname: 'mock_oauth_nickname#12345',
+                email: 'mock_email@example.com',
+                profileImageUrl: 'mock_profile_image.jpg',
+                role: ROLE.User,
+                mainDogId: null,
+                oauthId: '12345',
+                oauthAccessToken: OAUTH_ACCESS_TOKEN,
+                oauthRefreshToken: OAUTH_REFRESH_TOKEN,
+                refreshToken: VALID_REFRESH_TOKEN_100_YEARS,
+                createdAt: new Date('2019-01-01'),
+            }),
+        });
+        await insertMockDogs({
+            mockDogs: [
+                new Dogs({
+                    id: 1,
+                    walkDay: new DogWalkDay(),
+                    todayWalkTime: new TodayWalkTime(),
+                    name: '덕지',
+                    breedId: 1,
+                    gender: GENDER.Male,
+                    birth: null,
+                    isNeutered: true,
+                    weight: 2,
+                    profilePhotoUrl: 'mock_profile_photo.jpg',
+                    isWalking: false,
+                    updatedAt: new Date('2019-01-01'),
+                }),
+                new Dogs({
+                    id: 2,
+                    walkDay: new DogWalkDay(),
+                    todayWalkTime: new TodayWalkTime(),
+                    name: '루이',
+                    breedId: 2,
+                    gender: GENDER.Female,
+                    birth: null,
+                    isNeutered: false,
+                    weight: 1,
+                    profilePhotoUrl: 'mock_profile_photo2.jpg',
+                    isWalking: false,
+                    updatedAt: new Date('2019-01-01'),
+                }),
+            ],
+            userId: 1,
+        });
     });
 
     afterEach(async () => {


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->

## 링크 (Links)
https://www.notion.so/do0ori/test-utils-insert-method-e2e-test-17455e70f50843b38627d8b27de0e4e7

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
