### PR TITLE
backend/DANG-1101: BreedService 테스트 케이스 추가

### DIFF
--- a/backend/src/breed/breed.service.spec.ts
+++ b/backend/src/breed/breed.service.spec.ts
@@ -78,6 +78,18 @@ describe('BreedService', () => {
                 expect(breed).toEqual(['푸들', '에어데일 테리어']);
             });
         });
+
+        context('견종 목록이 존재하지 않으면', () => {
+            beforeEach(() => {
+                jest.spyOn(breedRepository, 'find').mockResolvedValue([]);
+            });
+
+            it('NotFoundException 예외를 던져야 한다.', async () => {
+                await expect(service.getKoreanNames()).rejects.toThrow(
+                    new NotFoundException('견종 목록을 찾을 수 없습니다.'),
+                );
+            });
+        });
     });
 
     describe('getRecommendedWalkAmountList', () => {

--- a/backend/src/breed/breed.service.spec.ts
+++ b/backend/src/breed/breed.service.spec.ts
@@ -1,3 +1,4 @@
+import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 
 import { getRepositoryToken } from '@nestjs/typeorm';
@@ -46,6 +47,57 @@ describe('BreedService', () => {
                     koreanName: '푸들',
                     recommendedWalkAmount: 60,
                 });
+            });
+        });
+    });
+
+    describe('getRecommendedWalkAmountList', () => {
+        const mockBreedList = [
+            {
+                englishName: 'Poodle',
+                id: 1,
+                koreanName: '푸들',
+                recommendedWalkAmount: 60,
+            },
+            {
+                englishName: 'Airedale Terrier',
+                id: 2,
+                koreanName: '에어데일 테리어',
+                recommendedWalkAmount: 1800,
+            },
+        ];
+
+        const breedIds = [1, 2];
+        const not_exist_BreedIds = [999, 1000];
+
+        beforeEach(() => {
+            jest.spyOn(breedRepository, 'find').mockResolvedValue(mockBreedList);
+        });
+
+        context('견종 id가 주어지면', () => {
+            it('해당 견종의 권장 산책량 리스트를 반환해야 한다.', async () => {
+                const recommendWalk = await service.getRecommendedWalkAmountList(breedIds);
+
+                expect(recommendWalk).toEqual([60, 1800]);
+            });
+        });
+
+        context('견종 id가 존재하지 않으면', () => {
+            it('NotFoundException 예외를 던져야 한다.', async () => {
+                await expect(service.getRecommendedWalkAmountList(not_exist_BreedIds)).rejects.toThrow(
+                    new NotFoundException('999에 대한 권장 산책량을 찾을 수 없습니다.'),
+                );
+            });
+        });
+
+        context('견종 목록이 빈 값이면', () => {
+            beforeEach(() => {
+                jest.spyOn(breedRepository, 'find').mockResolvedValue([]);
+            });
+            it('NotFoundException 예외를 던져야 한다.', async () => {
+                await expect(service.getRecommendedWalkAmountList(not_exist_BreedIds)).rejects.toThrow(
+                    new NotFoundException('999,1000 해당 견종을 찾을 수 없습니다.'),
+                );
             });
         });
     });

--- a/backend/src/breed/breed.service.spec.ts
+++ b/backend/src/breed/breed.service.spec.ts
@@ -51,6 +51,35 @@ describe('BreedService', () => {
         });
     });
 
+    describe('getKoreanNames', () => {
+        context('견종의 한국어 이름을 조회할 때', () => {
+            const mockBreedList = [
+                {
+                    englishName: 'Poodle',
+                    id: 1,
+                    koreanName: '푸들',
+                    recommendedWalkAmount: 60,
+                },
+                {
+                    englishName: 'Airedale Terrier',
+                    id: 2,
+                    koreanName: '에어데일 테리어',
+                    recommendedWalkAmount: 1800,
+                },
+            ];
+
+            beforeEach(() => {
+                jest.spyOn(breedRepository, 'find').mockResolvedValue(mockBreedList);
+            });
+
+            it('견종의 한국어 이름 리스트를 반환한다.', async () => {
+                const breed = await service.getKoreanNames();
+
+                expect(breed).toEqual(['푸들', '에어데일 테리어']);
+            });
+        });
+    });
+
     describe('getRecommendedWalkAmountList', () => {
         const mockBreedList = [
             {

--- a/backend/src/breed/breed.service.ts
+++ b/backend/src/breed/breed.service.ts
@@ -14,6 +14,10 @@ export class BreedService {
 
     async getKoreanNames(): Promise<string[]> {
         const breeds = await this.breedRepository.find({ select: ['koreanName'] });
+        if (!breeds.length) {
+            throw new NotFoundException(`견종 목록을 찾을 수 없습니다.`);
+        }
+
         return breeds.map((breed) => breed.koreanName);
     }
 

--- a/backend/src/breed/breed.service.ts
+++ b/backend/src/breed/breed.service.ts
@@ -22,7 +22,7 @@ export class BreedService {
         const breeds = await this.breedRepository.find({ where: { id: In(breedIds) } });
 
         if (!breeds.length) {
-            throw new NotFoundException();
+            throw new NotFoundException(`${breedIds} 해당 견종을 찾을 수 없습니다.`);
         }
 
         const breedMap = new Map(breeds.map((breed: Breed) => [breed.id, breed.recommendedWalkAmount]));
@@ -31,7 +31,7 @@ export class BreedService {
             const recommendedWalkAmount = breedMap.get(breedId);
 
             if (!recommendedWalkAmount) {
-                throw new NotFoundException(`Recommended walk amount not found for breedId: ${breedId}.`);
+                throw new NotFoundException(`${breedId}에 대한 권장 산책량을 찾을 수 없습니다.`);
             }
 
             return recommendedWalkAmount;


### PR DESCRIPTION
## 작업 내용 (Content)
- breedIds 배열을 입력받아 각 견종의 권장 산책량을 조회하는 getRecommendedWalkAmountList 메서드 구현
- 견종 ID가 존재하지 않거나 빈 배열일 경우 예외 처리 (NotFoundException)
- 조회된 견종 정보를 맵으로 변환하여 권장 산책량 추출 및 반환
- 해당 메서드의 동작을 검증하는 테스트 케이스 작성

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
