### PR TITLE
backend/DANG-1102: 에러 메세지 영어 -> 한글로 변경

### DIFF
--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -57,7 +57,7 @@ export class AuthService {
             if (error instanceof NotFoundException) {
                 return { oauthAccessToken, oauthRefreshToken, provider };
             }
-            this.logger.error(`Login error`, { trace: error.stack ?? 'No stack' });
+            this.logger.error(`로그인 에러`, { trace: error.stack ?? '스택 없음' });
             throw error;
         }
     }

--- a/backend/src/auth/guards/auth.guard.ts
+++ b/backend/src/auth/guards/auth.guard.ts
@@ -53,8 +53,8 @@ export class AuthGuard implements CanActivate {
         const authorizationHeader = request.headers.authorization;
 
         if (!authorizationHeader) {
-            const error = new UnauthorizedException('Authorization header is missing.');
-            this.logger.error(`Authorization header is missing.`, { trace: error.stack ?? 'No stack' });
+            const error = new UnauthorizedException('헤더에 Authorization 필드가 없습니다');
+            this.logger.error(`헤더에 Authorization 필드가 없습니다`, { trace: error.stack ?? 'No stack' });
             throw error;
         }
 
@@ -64,7 +64,7 @@ export class AuthGuard implements CanActivate {
             const error = new UnauthorizedException(
                 'Token does not exist in Authorization header or is in an invalid format.',
             );
-            this.logger.error(`Token does not exist in Authorization header or is in an invalid format.`, {
+            this.logger.error(`헤더의 Authorization 필드에 토큰이 없거나, 형식이 잘못되었습니다`, {
                 trace: error.stack ?? 'No stack',
             });
             throw error;

--- a/backend/src/auth/guards/oauth-data.guard.ts
+++ b/backend/src/auth/guards/oauth-data.guard.ts
@@ -28,8 +28,10 @@ export class OauthDataGuard implements CanActivate {
                 .filter(Boolean)
                 .join(', ');
 
-            const error = new UnauthorizedException(`OAuth data missing in cookies: ${missingFields}.`);
-            this.logger.error(`OAuthDataGuard failed: missing ${missingFields}.`, { trace: error.stack ?? 'No stack' });
+            const error = new UnauthorizedException(`쿠키에 OAuth 데이터가 없습니다: ${missingFields}`);
+            this.logger.error(`OAuthDataGuard : ${missingFields} 필드가 없습니다`, {
+                trace: error.stack ?? '스택 없음',
+            });
             throw error;
         }
 

--- a/backend/src/auth/guards/refresh-token.guard.ts
+++ b/backend/src/auth/guards/refresh-token.guard.ts
@@ -37,8 +37,8 @@ export class RefreshTokenGuard implements CanActivate {
         const token = request.cookies['refreshToken'];
 
         if (!token) {
-            const error = new UnauthorizedException('Refresh token not found in cookies.');
-            this.logger.error(`No refreshToken inside cookie.`, { trace: error.stack ?? 'No stack' });
+            const error = new UnauthorizedException('쿠키에 refreshToken이 없습니다');
+            this.logger.error(`쿠키에 refreshToken이 없습니다`, { trace: error.stack ?? '스택 없음' });
             throw error;
         }
 

--- a/backend/src/auth/interceptors/cookie.interceptor.ts
+++ b/backend/src/auth/interceptors/cookie.interceptor.ts
@@ -44,8 +44,11 @@ export class CookieInterceptor implements NestInterceptor {
                 } else if ('oauthAccessToken' in data && 'oauthRefreshToken' in data && 'provider' in data) {
                     this.setOauthCookies(response, data);
 
-                    const error = new NotFoundException('No matching user found. Please sign up for an account.');
-                    this.logger.error(`No matching user found`, error.stack ?? 'No Stack');
+                    const error = new NotFoundException('일치하는 유저를 찾을 수 없습니다. 계정을 생성해주세요');
+                    this.logger.error(
+                        `일치하는 유저를 찾을 수 없습니다. 계정을 생성해주세요`,
+                        error.stack ?? '스택 없음',
+                    );
                     throw error;
                 }
             }),

--- a/backend/src/auth/oauth/google.service.ts
+++ b/backend/src/auth/oauth/google.service.ts
@@ -59,11 +59,11 @@ export class GoogleService implements OauthService {
             return data;
         } catch (error) {
             if (axios.isAxiosError(error) && error.response) {
-                this.logger.error('Google: Failed to request token.', {
-                    trace: error.stack ?? 'No stack',
+                this.logger.error('Google: Token 발급 요청이 실패했습니다', {
+                    trace: error.stack ?? '스택 없음',
                     response: error.response.data,
                 });
-                error = new BadRequestException('Google: Failed to request token.');
+                error = new BadRequestException('Google: Token 발급 요청이 실패했습니다');
             }
             throw error;
         }
@@ -89,11 +89,11 @@ export class GoogleService implements OauthService {
             };
         } catch (error) {
             if (axios.isAxiosError(error) && error.response) {
-                this.logger.error('Google: Failed to request userInfo.', {
+                this.logger.error('Google: 유저 정보 조회 요청이 실패했습니다', {
                     trace: error.stack ?? 'No stack',
                     response: error.response.data,
                 });
-                error = new BadRequestException('Google: Failed to request userInfo.');
+                error = new BadRequestException('Google: 유저 정보 조회 요청이 실패했습니다');
             }
             throw error;
         }
@@ -117,11 +117,11 @@ export class GoogleService implements OauthService {
             );
         } catch (error) {
             if (axios.isAxiosError(error) && error.response) {
-                this.logger.error('Google: Failed to request token expiration.', {
+                this.logger.error('Google: Token 만료 기간 조회 요청이 실패했습니다', {
                     trace: error.stack ?? 'No stack',
                     response: error.response.data,
                 });
-                error = new BadRequestException('Google: Failed to request token expiration.');
+                error = new BadRequestException('Google: Token 만료 기간 조회 요청이 실패했습니다');
             }
             throw error;
         }
@@ -141,11 +141,11 @@ export class GoogleService implements OauthService {
             return data;
         } catch (error) {
             if (axios.isAxiosError(error) && error.response) {
-                this.logger.error('Google: Failed to request token refresh.', {
+                this.logger.error('Google: Token 갱신 요청이 실패했습니다', {
                     trace: error.stack ?? 'No stack',
                     response: error.response.data,
                 });
-                error = new BadRequestException('Google: Failed to request token refresh.');
+                error = new BadRequestException('Google: Token 갱신 요청이 실패했습니다');
             }
             throw error;
         }

--- a/backend/src/auth/oauth/kakao.service.ts
+++ b/backend/src/auth/oauth/kakao.service.ts
@@ -157,11 +157,11 @@ export class KakaoService implements OauthService {
             );
         } catch (error) {
             if (axios.isAxiosError(error) && error.response) {
-                this.logger.error('Kakao: 계정 unlink 요청이 실패했습니다', {
+                this.logger.error('Kakao: 계정 연결 끊기 요청이 실패했습니다', {
                     trace: error.stack ?? 'No stack',
                     response: error.response.data,
                 });
-                error = new BadRequestException('Kakao: 계정 unlink 요청이 실패했습니다');
+                error = new BadRequestException('Kakao: 계정 연결 끊기 요청이 실패했습니다');
             }
             throw error;
         }

--- a/backend/src/auth/oauth/kakao.service.ts
+++ b/backend/src/auth/oauth/kakao.service.ts
@@ -75,11 +75,11 @@ export class KakaoService implements OauthService {
             return data;
         } catch (error) {
             if (axios.isAxiosError(error) && error.response) {
-                this.logger.error(`Kakao: Failed to request token.`, {
-                    trace: error.stack ?? 'No stack',
+                this.logger.error(`Kakao: Token 발급 요청이 실패했습니다`, {
+                    trace: error.stack ?? '스택 없음',
                     response: error.response.data,
                 });
-                error = new BadRequestException('Kakao: Failed to request token.');
+                error = new BadRequestException('Kakao: Token 발급 요청이 실패했습니다');
             }
             throw error;
         }
@@ -105,11 +105,11 @@ export class KakaoService implements OauthService {
             };
         } catch (error) {
             if (axios.isAxiosError(error) && error.response) {
-                this.logger.error('Kakao: Failed to request userInfo.', {
+                this.logger.error('Kakao: 유저 정보 조회 요청이 실패했습니다', {
                     trace: error.stack ?? 'No stack',
                     response: error.response.data,
                 });
-                error = new BadRequestException('Kakao: Failed to request userInfo.');
+                error = new BadRequestException('Kakao: 유저 정보 조회 요청이 실패했습니다');
             }
             throw error;
         }
@@ -131,11 +131,11 @@ export class KakaoService implements OauthService {
             );
         } catch (error) {
             if (axios.isAxiosError(error) && error.response) {
-                this.logger.error('Kakao: Failed to request token expiration.', {
+                this.logger.error('Kakao: Token 만료 기간 조회 요청이 실패했습니다', {
                     trace: error.stack ?? 'No stack',
                     response: error.response.data,
                 });
-                error = new BadRequestException('Kakao: Failed to request token expiration.');
+                error = new BadRequestException('Kakao: Token 만료 기간 조회 요청이 실패했습니다');
             }
             throw error;
         }
@@ -157,11 +157,11 @@ export class KakaoService implements OauthService {
             );
         } catch (error) {
             if (axios.isAxiosError(error) && error.response) {
-                this.logger.error('Kakao: Failed to request unlink.', {
+                this.logger.error('Kakao: 계정 unlink 요청이 실패했습니다', {
                     trace: error.stack ?? 'No stack',
                     response: error.response.data,
                 });
-                error = new BadRequestException('Kakao: Failed to request unlink.');
+                error = new BadRequestException('Kakao: 계정 unlink 요청이 실패했습니다');
             }
             throw error;
         }
@@ -189,11 +189,11 @@ export class KakaoService implements OauthService {
             return data;
         } catch (error) {
             if (axios.isAxiosError(error) && error.response) {
-                this.logger.error('Kakao: Failed to request token refresh.', {
+                this.logger.error('Kakao: Token 갱신 요청이 실패했습니다', {
                     trace: error.stack ?? 'No stack',
                     response: error.response.data,
                 });
-                error = new BadRequestException('Kakao: Failed to request token refresh.');
+                error = new BadRequestException('Kakao: Token 갱신 요청이 실패했습니다');
             }
             throw error;
         }

--- a/backend/src/auth/oauth/naver.service.ts
+++ b/backend/src/auth/oauth/naver.service.ts
@@ -62,11 +62,11 @@ export class NaverService implements OauthService {
             return data;
         } catch (error) {
             if (axios.isAxiosError(error) && error.response) {
-                this.logger.error('Naver: Failed to request token.', {
+                this.logger.error('Naver: Token 발급 요청이 실패했습니다', {
                     trace: error.stack ?? 'No stack',
                     response: error.response.data,
                 });
-                error = new BadRequestException('Naver: Failed to request token.');
+                error = new BadRequestException('Naver: Token 발급 요청이 실패했습니다');
             }
             throw error;
         }
@@ -92,11 +92,11 @@ export class NaverService implements OauthService {
             };
         } catch (error) {
             if (axios.isAxiosError(error) && error.response) {
-                this.logger.error('Naver: Failed to request userInfo.', {
+                this.logger.error('Naver: 유저 정보 조회 요청이 실패했습니다', {
                     trace: error.stack ?? 'No stack',
                     response: error.response.data,
                 });
-                error = new BadRequestException('Naver: Failed to request userInfo.');
+                error = new BadRequestException('Naver: 유저 정보 조회 요청이 실패했습니다');
             }
             throw error;
         }
@@ -117,11 +117,11 @@ export class NaverService implements OauthService {
             );
         } catch (error) {
             if (axios.isAxiosError(error) && error.response) {
-                this.logger.error('Naver: Failed to request token expiration.', {
+                this.logger.error('Naver: Token 만료 기간 조회 요청이 실패했습니다', {
                     trace: error.stack ?? 'No stack',
                     response: error.response.data,
                 });
-                error = new BadRequestException('Naver: Failed to request token expiration.');
+                error = new BadRequestException('Naver: Token 만료 기간 조회 요청이 실패했습니다');
             }
             throw error;
         }
@@ -143,11 +143,11 @@ export class NaverService implements OauthService {
             return data;
         } catch (error) {
             if (axios.isAxiosError(error) && error.response) {
-                this.logger.error('Naver: Failed to request token refresh.', {
+                this.logger.error('Naver: Token 갱신 요청이 실패했습니다', {
                     trace: error.stack ?? 'No stack',
                     response: error.response.data,
                 });
-                error = new BadRequestException('Naver: Failed to request token refresh.');
+                error = new BadRequestException('Naver: Token 갱신 요청이 실패했습니다');
             }
             throw error;
         }

--- a/backend/src/common/database/database.module.ts
+++ b/backend/src/common/database/database.module.ts
@@ -38,7 +38,7 @@ import { WinstonLoggerService } from '../logger/winstonLogger.service';
             },
             async dataSourceFactory(options) {
                 if (!options) {
-                    throw new Error('Invalid options passed');
+                    throw new Error('옵션이 없습니다');
                 }
 
                 return getDataSourceByName('default') || addTransactionalDataSource(new DataSource(options));

--- a/backend/src/dog-walk-day/dog-walk-day.service.spec.ts
+++ b/backend/src/dog-walk-day/dog-walk-day.service.spec.ts
@@ -56,7 +56,7 @@ describe('DogWalkDayService', () => {
 
             it('NotFoundException 던져야 한다.', async () => {
                 await expect(dogWalkDayService.getWalkDayList([])).rejects.toThrow(
-                    new NotFoundException('walkDayIds 값을 찾을 수 없습니다.'),
+                    new NotFoundException('id가 인 레코드를 찾을 수 없습니다'),
                 );
             });
         });

--- a/backend/src/dog-walk-day/dog-walk-day.service.ts
+++ b/backend/src/dog-walk-day/dog-walk-day.service.ts
@@ -18,8 +18,8 @@ export class DogWalkDayService {
     async getWalkDayList(walkDayIds: number[]): Promise<number[][]> {
         const foundDays = await this.dogWalkDayRepository.find({ where: { id: In(walkDayIds) } });
         if (!foundDays.length) {
-            this.logger.error('walkDayIds 데이터를 찾을 수 없습니다.', '');
-            throw new NotFoundException('walkDayIds 값을 찾을 수 없습니다.');
+            this.logger.error(`id가 ${walkDayIds}인 레코드를 찾을 수 없습니다`, '');
+            throw new NotFoundException(`id가 ${walkDayIds}인 레코드를 찾을 수 없습니다`);
         }
 
         const result: number[][] = [];

--- a/backend/src/dogs/dogs.service.ts
+++ b/backend/src/dogs/dogs.service.ts
@@ -52,7 +52,7 @@ export class DogsService {
 
             return this.usersDogsService.create({ userId, dogId: dog.id });
         } catch (error) {
-            this.logger.error(`Unknown breed.`, { trace: error.stack ?? 'No stack' });
+            this.logger.error(`존재하지 않는 breed입니다`, { trace: error.stack ?? '스택 없음' });
             throw error;
         }
     }

--- a/backend/src/dogs/dogs.service.ts
+++ b/backend/src/dogs/dogs.service.ts
@@ -52,7 +52,7 @@ export class DogsService {
 
             return this.usersDogsService.create({ userId, dogId: dog.id });
         } catch (error) {
-            this.logger.error(`존재하지 않는 breed입니다`, { trace: error.stack ?? '스택 없음' });
+            this.logger.error(`존재하지 않는 견종입니다`, { trace: error.stack ?? '스택 없음' });
             throw error;
         }
     }

--- a/backend/src/dogs/guards/auth-dog.guard.ts
+++ b/backend/src/dogs/guards/auth-dog.guard.ts
@@ -24,9 +24,9 @@ export class AuthDogGuard implements CanActivate {
         const id = request.query.dogId || request.params.id;
 
         if (!this.isInt(id)) {
-            const error = new BadRequestException('Invalid dogId.');
-            this.logger.error('Invalid dogId.', {
-                trace: error.stack ?? 'No stack',
+            const error = new BadRequestException('dogId가 정수가 아닙니다');
+            this.logger.error('dogId가 정수가 아닙니다', {
+                trace: error.stack ?? '스택 없음',
             });
             throw error;
         }
@@ -38,8 +38,8 @@ export class AuthDogGuard implements CanActivate {
         const [owned] = await this.usersService.checkDogOwnership(userId, dogId);
 
         if (!owned) {
-            const error = new ForbiddenException(`User ${userId} does not own the dog ${dogId}.`);
-            this.logger.error(`User ${userId} does not own the dog ${dogId}.`, { trace: error.stack ?? 'No stack' });
+            const error = new ForbiddenException(`유저 ${userId}은/는 강아지${dogId}의 주인이 아닙니다`);
+            this.logger.error(`유저 ${userId}은/는 ${dogId}의 주인이 아닙니다`, { trace: error.stack ?? '스택 없음' });
             throw error;
         }
     }

--- a/backend/src/journals/guards/auth-journal.guard.ts
+++ b/backend/src/journals/guards/auth-journal.guard.ts
@@ -24,9 +24,11 @@ export class AuthJournalGuard implements CanActivate {
         const [owned] = await this.journalsService.checkJournalOwnership(userId, journalId);
 
         if (!owned) {
-            const error = new ForbiddenException(`User ${userId} does not have access to journal ${journalId}`);
-            this.logger.error(`User ${userId} does not have access to journal ${journalId}`, {
-                trace: error.stack ?? 'No stack',
+            const error = new ForbiddenException(
+                `유저 ${userId}은/는 산책일지 ${journalId}에 대한 접근 권한이 없습니다`,
+            );
+            this.logger.error(`유저 ${userId}은/는 산책일지 ${journalId}에 대한 접근 권한이 없습니다`, {
+                trace: error.stack ?? '스택 없음',
             });
             throw error;
         }

--- a/backend/src/s3/s3.service.ts
+++ b/backend/src/s3/s3.service.ts
@@ -49,7 +49,7 @@ export class S3Service {
     async deleteObjects(userId: number, filenames: string[]) {
         const objectArray = filenames.map((curFilename) => {
             if (!this.checkUserIdInFilename(userId, curFilename)) {
-                throw new ForbiddenException(`User ${userId} is not owner of the file ${curFilename}`);
+                throw new ForbiddenException(`유저 ${userId}은 ${curFilename}에 대한 접근 권한이 없습니다`);
             }
             return { Key: curFilename };
         });
@@ -64,15 +64,15 @@ export class S3Service {
         const command = new DeleteObjectsCommand(input);
         try {
             await this.s3Client.send(command);
-            this.logger.log(`Successfully deleted ${objectArray.map((cur) => cur.Key)}`);
+            this.logger.log(`${BUCKET_NAME} 버킷에서 ${filenames} 파일을 성공적으로 삭제했습니다`);
         } catch (error) {
-            this.logger.error(`Can't delete files from S3 bucket ${BUCKET_NAME}`, error ?? error.stack);
+            this.logger.error(`${BUCKET_NAME} 버킷에서 ${filenames} 파일 삭제에 실패했습니다`, error ?? error.stack);
         }
     }
 
     async deleteSingleObject(userId: number, filename: string) {
         if (!this.checkUserIdInFilename(userId, filename)) {
-            throw new ForbiddenException(`User ${userId} is not owner of the file ${filename}`);
+            throw new ForbiddenException(`유저 ${userId}은/는 ${filename}에 대한 접근 권한이 없습니다`);
         }
 
         const command = new DeleteObjectCommand({
@@ -82,9 +82,9 @@ export class S3Service {
 
         try {
             await this.s3Client.send(command);
-            this.logger.log(`Successfully deleted ${filename}`);
+            this.logger.log(`${BUCKET_NAME} 버킷에서 ${filename} 파일을 성공적으로 삭제했습니다`);
         } catch (error) {
-            this.logger.error(`Can't delete ${filename} from S3 bucket ${BUCKET_NAME}`, error ?? error.stack);
+            this.logger.error(`${BUCKET_NAME} 버킷에서 ${filename} 파일 삭제에 실패했습니다`, error ?? error.stack);
         }
     }
 
@@ -98,9 +98,9 @@ export class S3Service {
 
         try {
             await this.s3Client.send(command);
-            this.logger.log(`Successfully deleted ${filename}`);
+            this.logger.log(`${BUCKET_NAME} 버킷에서 ${filename} 파일을 성공적으로 삭제했습니다`);
         } catch (error) {
-            this.logger.error(`Can't delete ${filename} from S3 bucket ${BUCKET_NAME}`, error ?? error.stack);
+            this.logger.error(`${BUCKET_NAME} 버킷에서 ${filename} 파일 삭제에 실패했습니다`, error ?? error.stack);
         }
     }
 }

--- a/backend/src/statistics/statistics.service.ts
+++ b/backend/src/statistics/statistics.service.ts
@@ -101,10 +101,10 @@ export class StatisticsService {
         ].filter(Boolean);
 
         if (mismatchedLengths.length > 0) {
-            const error = new NotFoundException(`Data missing or mismatched for dogId: ${ownDogIds}.`);
+            const error = new NotFoundException(`dogId: ${ownDogIds}에 대한 데이터가 누락되었거나 일치하지 않습니다.`);
             this.logger.error(
-                `Data missing or mismatched for dogId: ${ownDogIds}. Expected length: ${length}. Mismatched data: ${mismatchedLengths.join(', ')}`,
-                { trace: error.stack ?? 'No stack' },
+                `dogId: ${ownDogIds}에 대한 데이터가 누락되었거나 일치하지 않습니다. 올바른 길이: ${length}. 일치하지 않는 데이터: ${mismatchedLengths.join(', ')}`,
+                { trace: error.stack ?? '스택 없음' },
             );
             throw error;
         }

--- a/backend/src/today-walk-time/today-walk-time.service.ts
+++ b/backend/src/today-walk-time/today-walk-time.service.ts
@@ -43,9 +43,9 @@ export class TodayWalkTimeService {
     async getWalkTimeList(walkTimeIds: number[]) {
         const walkTimeListBeforeCheck = await this.todayWalkTimeRepository.find({ where: { id: In(walkTimeIds) } });
         if (!walkTimeListBeforeCheck.length) {
-            const error = new NotFoundException(`No walkTime found for the provided IDs: ${walkTimeIds}.`);
-            this.logger.error(`No walkTime found for the provided IDs: ${walkTimeIds}.`, {
-                trace: error.stack ?? 'No stack',
+            const error = new NotFoundException(`id: ${walkTimeIds}와 일치하는 레코드가 없습니다`);
+            this.logger.error(`id: ${walkTimeIds}와 일치하는 레코드가 없습니다`, {
+                trace: error.stack ?? '스택 없음',
             });
             throw error;
         }

--- a/backend/src/utils/manipulate.util.ts
+++ b/backend/src/utils/manipulate.util.ts
@@ -45,7 +45,7 @@ export function makeSubObjectsArray(
     Array.isArray(newAttributes) ? newAttributes : [newAttributes];
 
     if (srcAttributes.length != newAttributes.length) {
-        throw new Error('srcAttributes and targetAttributes must have same length');
+        throw new Error('srcAttributes와 targetAttributes의 길이가 다릅니다');
     }
     targetArr.map((cur) => {
         const obj: { [key: string]: any } = {};

--- a/backend/src/utils/ms.util.ts
+++ b/backend/src/utils/ms.util.ts
@@ -58,11 +58,11 @@ function msFn(value: StringValue): number {
         if (typeof value === 'string') {
             return parse(value);
         }
-        throw new Error('Value provided to ms() must be a string or number.');
+        throw new Error('인자의 타입이 string 또는 number가 아닙니다');
     } catch (error) {
         const message = isError(error)
             ? `${error.message}. value=${JSON.stringify(value)}`
-            : 'An unknown error has occurred.';
+            : '알 수 없는 에러가 발생했습니다';
         throw new Error(message);
     }
 }

--- a/backend/src/walk/guards/auth-dogs.guard.ts
+++ b/backend/src/walk/guards/auth-dogs.guard.ts
@@ -40,11 +40,14 @@ export class AuthDogsGuard implements CanActivate {
 
         if (!owned) {
             const error = new ForbiddenException(
-                `유저 ${userId}은/는 다음 강아지(들)의 주인이 아닙니다: ${notFoundDogIds.join(', ')}`,
+                `유저 ${userId}은/는 다음 강아지(들)에 대한 접근 권한이 없습니다: ${notFoundDogIds.join(', ')}`,
             );
-            this.logger.error(`유저 ${userId}은/는 다음 강아지(들)의 주인이 아닙니다: ${notFoundDogIds.join(', ')}`, {
-                trace: error.stack ?? 'No stack',
-            });
+            this.logger.error(
+                `유저 ${userId}은/는 다음 강아지(들)에 대한 접근 권한이 없습니다: ${notFoundDogIds.join(', ')}`,
+                {
+                    trace: error.stack ?? 'No stack',
+                },
+            );
             throw error;
         }
     }

--- a/backend/src/walk/guards/auth-dogs.guard.ts
+++ b/backend/src/walk/guards/auth-dogs.guard.ts
@@ -25,10 +25,8 @@ export class AuthDogsGuard implements CanActivate {
         const body = request.body.dogs || request.body;
 
         if (!isTypedArray(body, 'number')) {
-            const error = new BadRequestException(
-                'Invalid request body. The request body should be an array of dogIds as numbers.',
-            );
-            this.logger.error('Invalid request body. The request body should be an array of dogIds as numbers.', {
+            const error = new BadRequestException('유효하지 않은 request body: dogIds가 number 타입의 배열이 아닙니다');
+            this.logger.error('유효하지 않은 request body: dogIds가 number 타입의 배열이 아닙니다', {
                 trace: error.stack ?? 'No stack',
             });
             throw error;
@@ -42,9 +40,9 @@ export class AuthDogsGuard implements CanActivate {
 
         if (!owned) {
             const error = new ForbiddenException(
-                `User ${userId} does not own the following dog(s): ${notFoundDogIds.join(', ')}.`,
+                `유저 ${userId}은/는 다음 강아지(들)의 주인이 아닙니다: ${notFoundDogIds.join(', ')}`,
             );
-            this.logger.error(`User ${userId} does not own the following dog(s): ${notFoundDogIds.join(', ')}.`, {
+            this.logger.error(`유저 ${userId}은/는 다음 강아지(들)의 주인이 아닙니다: ${notFoundDogIds.join(', ')}`, {
                 trace: error.stack ?? 'No stack',
             });
             throw error;

--- a/backend/test/dogs.e2e-spec.ts
+++ b/backend/test/dogs.e2e-spec.ts
@@ -292,7 +292,7 @@ describe('DogsController (e2e)', () => {
                     .expect(204);
 
                 const updatedDog = await dataSource.getRepository(Dogs).findOne({ where: { id: 1 } });
-                if (!updatedDog) throw new Error('강아지 1을 찾을 수 없습니다');
+                if (!updatedDog) throw new Error('id가 1인 강아지를 찾을 수 없습니다');
                 updatedDog.breed = (updatedDog.breed as any).koreanName;
 
                 expect(updatedDog).toEqual({

--- a/backend/test/dogs.e2e-spec.ts
+++ b/backend/test/dogs.e2e-spec.ts
@@ -292,7 +292,7 @@ describe('DogsController (e2e)', () => {
                     .expect(204);
 
                 const updatedDog = await dataSource.getRepository(Dogs).findOne({ where: { id: 1 } });
-                if (!updatedDog) throw new Error('Dog not found');
+                if (!updatedDog) throw new Error('강아지 1을 찾을 수 없습니다');
                 updatedDog.breed = (updatedDog.breed as any).koreanName;
 
                 expect(updatedDog).toEqual({

--- a/backend/test/journals.e2e-spec.ts
+++ b/backend/test/journals.e2e-spec.ts
@@ -420,12 +420,12 @@ describe('JournalsController (e2e)', () => {
                 const dog1WalkDay = await dataSource
                     .getRepository(DogWalkDay)
                     .findOne({ where: { id: 1 }, select: days });
-                if (!dog1WalkDay) throw new Error('dog1WalkDay를 찾을 수 없습니다');
+                if (!dog1WalkDay) throw new Error('id가 1인 산책일지를 찾을 수 없습니다');
 
                 const dog2WalkDay = await dataSource
                     .getRepository(DogWalkDay)
                     .findOne({ where: { id: 2 }, select: days });
-                if (!dog2WalkDay) throw new Error('dog2WalkDay를 찾을 수 없습니다');
+                if (!dog2WalkDay) throw new Error('id가 2인 산책일지를 찾을 수 없습니다');
 
                 const expectedWalkDays = {
                     mon: 0,
@@ -708,12 +708,12 @@ describe('JournalsController (e2e)', () => {
                     .expect(204);
 
                 const updatedJournal = await dataSource.getRepository(Journals).findOne({ where: { id: 1 } });
-                if (!updatedJournal) throw new Error('산책일지 1을 찾을 수 없습니다');
+                if (!updatedJournal) throw new Error('id가 1인 산책일지를 찾을 수 없습니다');
 
                 const updatedJournalPhotos = await dataSource
                     .getRepository(JournalPhotos)
                     .find({ where: { journalId: 1 } });
-                if (!updatedJournalPhotos) throw new Error('산책일지 1의 사진을 찾을 수 없습니다');
+                if (!updatedJournalPhotos) throw new Error('id가 1인 산책일지를 찾을 수 없습니다');
 
                 expect(updatedJournal.memo).toBe(updateJournalMock.memo);
                 expect(updatedJournalPhotos).toHaveLength(updateJournalMock.photoUrls.length);
@@ -825,12 +825,12 @@ describe('JournalsController (e2e)', () => {
                 const dog1WalkDay = await dataSource
                     .getRepository(DogWalkDay)
                     .findOne({ where: { id: 1 }, select: days });
-                if (!dog1WalkDay) throw new Error('dog1WalkDay를 찾을 수 없습니다');
+                if (!dog1WalkDay) throw new Error('id가 1인 산책일지를 찾을 수 없습니다');
 
                 const dog2WalkDay = await dataSource
                     .getRepository(DogWalkDay)
                     .findOne({ where: { id: 2 }, select: days });
-                if (!dog2WalkDay) throw new Error('dog2WalkDay를 찾을 수 없습니다');
+                if (!dog2WalkDay) throw new Error('id가 2인 산책일지를 찾을 수 없습니다');
 
                 const expectedWalkDays = {
                     mon: 0,

--- a/backend/test/journals.e2e-spec.ts
+++ b/backend/test/journals.e2e-spec.ts
@@ -420,12 +420,12 @@ describe('JournalsController (e2e)', () => {
                 const dog1WalkDay = await dataSource
                     .getRepository(DogWalkDay)
                     .findOne({ where: { id: 1 }, select: days });
-                if (!dog1WalkDay) throw new Error('dog1WalkDay not found');
+                if (!dog1WalkDay) throw new Error('dog1WalkDay를 찾을 수 없습니다');
 
                 const dog2WalkDay = await dataSource
                     .getRepository(DogWalkDay)
                     .findOne({ where: { id: 2 }, select: days });
-                if (!dog2WalkDay) throw new Error('dog2WalkDay not found');
+                if (!dog2WalkDay) throw new Error('dog2WalkDay를 찾을 수 없습니다');
 
                 const expectedWalkDays = {
                     mon: 0,
@@ -708,12 +708,12 @@ describe('JournalsController (e2e)', () => {
                     .expect(204);
 
                 const updatedJournal = await dataSource.getRepository(Journals).findOne({ where: { id: 1 } });
-                if (!updatedJournal) throw new Error('Journal not found');
+                if (!updatedJournal) throw new Error('산책일지 1을 찾을 수 없습니다');
 
                 const updatedJournalPhotos = await dataSource
                     .getRepository(JournalPhotos)
                     .find({ where: { journalId: 1 } });
-                if (!updatedJournalPhotos) throw new Error('Journal Photo not found');
+                if (!updatedJournalPhotos) throw new Error('산책일지 1의 사진을 찾을 수 없습니다');
 
                 expect(updatedJournal.memo).toBe(updateJournalMock.memo);
                 expect(updatedJournalPhotos).toHaveLength(updateJournalMock.photoUrls.length);
@@ -825,12 +825,12 @@ describe('JournalsController (e2e)', () => {
                 const dog1WalkDay = await dataSource
                     .getRepository(DogWalkDay)
                     .findOne({ where: { id: 1 }, select: days });
-                if (!dog1WalkDay) throw new Error('dog1WalkDay not found');
+                if (!dog1WalkDay) throw new Error('dog1WalkDay를 찾을 수 없습니다');
 
                 const dog2WalkDay = await dataSource
                     .getRepository(DogWalkDay)
                     .findOne({ where: { id: 2 }, select: days });
-                if (!dog2WalkDay) throw new Error('dog2WalkDay not found');
+                if (!dog2WalkDay) throw new Error('dog2WalkDay를 찾을 수 없습니다');
 
                 const expectedWalkDays = {
                     mon: 0,

--- a/backend/test/users.e2e-spec.ts
+++ b/backend/test/users.e2e-spec.ts
@@ -91,7 +91,7 @@ describe('UsersController (e2e)', () => {
                     .expect(204);
 
                 const updatedUser = await dataSource.getRepository(Users).findOne({ where: { id: 1 } });
-                if (!updatedUser) throw new Error('User not found');
+                if (!updatedUser) throw new Error('유저 1을 찾을 수 없습니다');
                 updatedUser.nickname = updatedUser.nickname.split('#')[0];
                 expect(updatedUser).toMatchObject({ ...mockUserInfo, ...updateMockUser });
             });

--- a/backend/test/users.e2e-spec.ts
+++ b/backend/test/users.e2e-spec.ts
@@ -91,7 +91,7 @@ describe('UsersController (e2e)', () => {
                     .expect(204);
 
                 const updatedUser = await dataSource.getRepository(Users).findOne({ where: { id: 1 } });
-                if (!updatedUser) throw new Error('유저 1을 찾을 수 없습니다');
+                if (!updatedUser) throw new Error('id가 1인 유저를 찾을 수 없습니다');
                 updatedUser.nickname = updatedUser.nickname.split('#')[0];
                 expect(updatedUser).toMatchObject({ ...mockUserInfo, ...updateMockUser });
             });


### PR DESCRIPTION
## 작업 내용 (Content)
가독성, 작업의 편의성을 높이기 위해 
에러 메세지를 영어에서 한글로 변경하였습니다.

## 링크 (Links)

## 기타 사항 (Etc)
공통적으로 적용된 규칙들
- 문장 끝의 온점은 필요하지 않은 것 같아 찍지 않았습니다.
- id가 n인 주체를 표현할 때, 주체 + n으로 표기하였습니다.
  ex) id가 1인 유저 : 유저 1
        뒤에 관사가 올 때, 숫자에 따라 '은' 또는 '는'이 올 수 있어 은/는으로 표기하였습니다.
- DB의 한 행 : 레코드로 표현하였습니다.
- validation에 통과하지 못했을 때 : [validation 대상]이 [적합한 타입]이 아닙니다. 로 표기하였습니다.
  ex) dogId가 정수가 아닙니다
- 권한이 없을 때 : a는 b에 대한 접근 권한이 없습니다.

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
