### PR TITLE
backend/DANG-1103: API response time script 작성

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -20,6 +20,7 @@
         "test:e2e": "cross-env NODE_ENV=test jest --config ./test/jest-e2e.json --maxWorkers=1",
         "test:e2e-watch": "cross-env NODE_ENV=test jest --watch --config ./test/jest-e2e.json --maxWorkers=1",
         "test:only-changed": "cross-env NODE_ENV=test jest --onlyChanged",
+        "test:response-time": "cross-env NODE_ENV=test ts-node ./test/performance/response-time.ts",
         "prepare": "cd .. && husky backend/.husky"
     },
     "lint-staged": {

--- a/backend/src/auth/guards/oauth-data.guard.ts
+++ b/backend/src/auth/guards/oauth-data.guard.ts
@@ -5,6 +5,7 @@ import { WinstonLoggerService } from '../../common/logger/winstonLogger.service'
 @Injectable()
 export class OauthDataGuard implements CanActivate {
     constructor(private readonly logger: WinstonLoggerService) {}
+
     async canActivate(context: ExecutionContext): Promise<boolean> {
         const request = context.switchToHttp().getRequest();
         const oauthData = this.extractOauthDataFromCookies(request);

--- a/backend/src/common/database/database.module.ts
+++ b/backend/src/common/database/database.module.ts
@@ -8,6 +8,16 @@ import { addTransactionalDataSource, getDataSourceByName } from 'typeorm-transac
 
 import BreedSeeder from './seeds/breed.seeder';
 
+import { Breed } from '../../breed/breed.entity';
+import { DogWalkDay } from '../../dog-walk-day/dog-walk-day.entity';
+import { Dogs } from '../../dogs/dogs.entity';
+import { Excrements } from '../../excrements/excrements.entity';
+import { JournalPhotos } from '../../journal-photos/journal-photos.entity';
+import { Journals } from '../../journals/journals.entity';
+import { JournalsDogs } from '../../journals-dogs/journals-dogs.entity';
+import { TodayWalkTime } from '../../today-walk-time/today-walk-time.entity';
+import { Users } from '../../users/users.entity';
+import { UsersDogs } from '../../users-dogs/users-dogs.entity';
 import { color } from '../../utils/ansi.util';
 import { WinstonLoggerService } from '../logger/winstonLogger.service';
 
@@ -27,7 +37,18 @@ import { WinstonLoggerService } from '../logger/winstonLogger.service';
                     username: config.get<string>('MYSQL_ROOT_USER'),
                     password: config.get<string>('MYSQL_ROOT_PASSWORD'),
                     database: config.get<string>('MYSQL_DATABASE'),
-                    entities: isTest ? ['src/**/*.entity{.ts,.js}'] : ['dist/**/*.entity{.ts,.js}'],
+                    entities: [
+                        Breed,
+                        DogWalkDay,
+                        Dogs,
+                        Excrements,
+                        JournalPhotos,
+                        Journals,
+                        JournalsDogs,
+                        TodayWalkTime,
+                        Users,
+                        UsersDogs,
+                    ],
                     synchronize: true,
                     timezone: 'Z',
                     legacySpatialSupport: false,

--- a/backend/test/performance/__mocks__/oauth.service.ts
+++ b/backend/test/performance/__mocks__/oauth.service.ts
@@ -1,0 +1,27 @@
+import { RequestToken, RequestTokenRefresh, RequestUserInfo } from '../../../src/auth/oauth/oauth.service.interface';
+
+export const MockOauthService = {
+    requestToken: () =>
+        ({
+            access_token: 'mock_oauth_access_token',
+            refresh_token: 'mock_oauth_refresh_token',
+        }) as RequestToken,
+
+    requestUserInfo: () =>
+        ({
+            oauthId: '12345',
+            oauthNickname: 'mock_oauth_nickname',
+            email: 'mock_email@example.com',
+            profileImageUrl: 'mock_profile_image.jpg',
+        }) as RequestUserInfo,
+
+    requestTokenExpiration: () => {},
+
+    requestUnlink: () => {},
+
+    requestTokenRefresh: () =>
+        ({
+            access_token: 'new_mock_oauth_access_token',
+            refresh_token: 'new_mock_oauth_refresh_token',
+        }) as RequestTokenRefresh,
+};

--- a/backend/test/performance/__mocks__/s3.service.ts
+++ b/backend/test/performance/__mocks__/s3.service.ts
@@ -1,0 +1,26 @@
+import { ForbiddenException } from '@nestjs/common';
+
+import { PresignedUrlInfo } from '../../../src/s3/types/presigned-url-info.type';
+import { generateUuid } from '../../../src/utils/hash.util';
+
+export const MockS3Service = {
+    createPresignedUrlWithClientForPut: (userId: number, type: string[]): PresignedUrlInfo[] => {
+        const filenameArray = type.map((curType) => `${userId}/${generateUuid()}.${curType}`);
+        return filenameArray.map((curFileName) => ({
+            filename: curFileName,
+            url: 'https://aws.s3/' + curFileName,
+        }));
+    },
+
+    deleteObjects: (userId: number, filenames: string[]) => {
+        for (const curFilename of filenames) {
+            if (parseInt(curFilename.split('/')[0]) !== userId) {
+                throw new ForbiddenException(`User ${userId} is not owner of the file ${curFilename}`);
+            }
+        }
+    },
+
+    deleteSingleObject: () => {},
+
+    deleteObjectFolder: () => {},
+};

--- a/backend/test/performance/response-time.ts
+++ b/backend/test/performance/response-time.ts
@@ -1,0 +1,149 @@
+import { exec } from 'node:child_process';
+
+import { promisify } from 'node:util';
+
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getDataSourceToken } from '@nestjs/typeorm';
+import * as cookieParser from 'cookie-parser';
+import { DataSource } from 'typeorm';
+import { initializeTransactionalContext } from 'typeorm-transactional';
+
+import { MockOauthService } from './__mocks__/oauth.service';
+
+import { MockS3Service } from './__mocks__/s3.service';
+
+import { AppModule } from '../../src/app.module';
+import { GoogleService } from '../../src/auth/oauth/google.service';
+import { KakaoService } from '../../src/auth/oauth/kakao.service';
+import { NaverService } from '../../src/auth/oauth/naver.service';
+import { S3Service } from '../../src/s3/s3.service';
+import { ROLE } from '../../src/users/types/role.type';
+import { Users } from '../../src/users/users.entity';
+import { generateUuid } from '../../src/utils/hash.util';
+import { OAUTH_ACCESS_TOKEN, OAUTH_REFRESH_TOKEN, VALID_REFRESH_TOKEN_100_YEARS } from '../constants';
+
+const execPromisified = promisify(exec);
+
+let app: INestApplication;
+let dataSource: DataSource;
+
+export const setupTestApp = async () => {
+    initializeTransactionalContext();
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+        imports: [AppModule],
+    })
+        .overrideProvider(GoogleService)
+        .useValue(MockOauthService)
+        .overrideProvider(KakaoService)
+        .useValue(MockOauthService)
+        .overrideProvider(NaverService)
+        .useValue(MockOauthService)
+        .overrideProvider(S3Service)
+        .useValue(MockS3Service)
+        .compile();
+
+    app = moduleFixture.createNestApplication();
+
+    app.use(cookieParser());
+
+    await (async () => {
+        await app.listen(process.env.PORT!, () => {
+            console.log(`Test server running at http://${process.env.MYSQL_HOST}:${process.env.PORT}`);
+        });
+    })();
+
+    dataSource = app.get(getDataSourceToken());
+};
+
+export const closeTestApp = async () => {
+    await dataSource.destroy();
+    await app.close();
+};
+
+export const insertTestData = async (n: number): Promise<void> => {
+    const mockUsers = Array(n)
+        .fill(undefined)
+        .map((_, i) => ({
+            nickname: `${i + 1}#${generateUuid()}`,
+            email: 'test@mail.com',
+            profileImageUrl: 'default/profile.png',
+            role: ROLE.User,
+            mainDogId: null,
+            oauthId: (i + 1).toString(),
+            oauthAccessToken: OAUTH_ACCESS_TOKEN,
+            oauthRefreshToken: OAUTH_REFRESH_TOKEN,
+            refreshToken: VALID_REFRESH_TOKEN_100_YEARS,
+        }));
+
+    await dataSource.getRepository(Users).insert(mockUsers);
+
+    console.log(`Inserted ${n} test data into each entity table`);
+};
+
+export const deleteTestData = async (): Promise<void> => {
+    await dataSource.query('SET FOREIGN_KEY_CHECKS = 0;');
+
+    for (const entityMetadata of dataSource.entityMetadatas) {
+        await dataSource.getRepository(entityMetadata.name).clear();
+    }
+
+    await dataSource.query('SET FOREIGN_KEY_CHECKS = 1;');
+
+    console.log('Cleared all test data');
+};
+
+const runPostmanCollectionWithNewman = async (
+    collectionId: string,
+    requestOrFolderId: string,
+    iterationCount: number,
+): Promise<void> => {
+    const command = `postman collection run ${collectionId} -i ${requestOrFolderId} -n ${iterationCount} --color on`;
+
+    try {
+        const { stdout, stderr } = await execPromisified(command, { encoding: 'utf8' });
+        console.log('Postman collection executed successfully.');
+        console.log('stdout:', stdout);
+        console.error('stderr:', stderr);
+    } catch (error) {
+        console.error(`Failed to execute Postman collection: ${error}`);
+    }
+};
+
+const DATA_SIZE = parseInt(process.env.DATA_SIZE!);
+const COLLECTION_ID = process.env.COLLECTION_ID!;
+const REQUEST_OR_FOLDER_ID = process.env.REQUEST_OR_FOLDER_ID!;
+const ITERATION_COUNT = parseInt(process.env.ITERATION_COUNT!);
+
+const validateParameters = () => {
+    if (isNaN(DATA_SIZE)) {
+        throw new Error('DATA_SIZE가 정의되지 않았거나 유효한 숫자가 아닙니다. .env.test 파일을 수정해주세요.');
+    }
+    if (!COLLECTION_ID) {
+        throw new Error('COLLECTION_ID가 정의되지 않았습니다. .env.test 파일을 수정해주세요.');
+    }
+    if (!REQUEST_OR_FOLDER_ID) {
+        throw new Error('REQUEST_OR_FOLDER_ID가 정의되지 않았습니다. .env.test 파일을 수정해주세요.');
+    }
+    if (isNaN(ITERATION_COUNT)) {
+        throw new Error('ITERATION_COUNT가 정의되지 않았거나 유효한 숫자가 아닙니다. .env.test 파일을 수정해주세요.');
+    }
+};
+
+const runTests = async () => {
+    validateParameters();
+    await setupTestApp();
+
+    try {
+        await insertTestData(DATA_SIZE);
+        await runPostmanCollectionWithNewman(COLLECTION_ID, REQUEST_OR_FOLDER_ID, ITERATION_COUNT);
+    } catch (error) {
+        console.error('Error during test execution:', error);
+    } finally {
+        await deleteTestData();
+        await app.close();
+    }
+};
+
+runTests();


### PR DESCRIPTION
## 작업 내용 (Content)

<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- 경로 설정 차이에 따른 EntityMetadataNotFoundError를 방지하기 
  - typeorm으로 database option 설정 시 entities에 entity 파일의 경로 패턴을 넣게 되는데 실행 환경에 따라 `EntityMetadataNotFoundError: No metadata for "Entity" was found.` 오류가 발생하는 관계로 이를 방지하기 위해 entity를 직접 넣어주었다.
  - typeorm github에서도 비슷한 issue를 발견할 수 있었고 모두 entity를 직접 넣어주는 것이 해결 방안이었다. Readme 공식 문서에서도 entity를 추가해주는 방식을 사용하는 것을 확인할 수 있다.
- API response time script 작성 
  - Test를 위한 환경 변수는 `.env.test` 파일에 작성한다. 기존 파일에 다음 변수들을 추가해야 한다.
    - `DATA_SIZE`
    - `COLLECTION_ID`
    - `REQUEST_OR_FOLDER_ID`
    - `ITERATION_COUNT`
  - TestingModule을 활용해 test server를 구동한다.
  - 지정한 개수의 test data를 test database에 삽입한다.
  - postman CLI를 활용해 지정된 collection을 실행한다.
  - test database를 깨끗이 비운다.
- response time script를 실행하기 위한 script 명령어를 추가했다. ts-node를 사용하므로 `npm install -g ts-node`로 설치한 후 명령어를 사용해야 한다. 다음은 사용자 정보 조회 API에 대한 test 결과 예시이다.
  ```bash
  $ npm run test:response-time
  
  > nest-js-example@0.0.1 test:response-time
  > cross-env NODE_ENV=test ts-node ./test/performance/response-time.ts
  
  Test server running at http://localhost:3333
  Inserted 10 test data into each entity table
  Postman collection executed successfully.
  stdout: postman
  
  dangdang-walk
  
  ┌─────────────────────────┬──────────────────┬─────────────────┐
  │                         │         executed │          failed │
  ├─────────────────────────┼──────────────────┼─────────────────┤
  │              iterations │              100 │               0 │
  ├─────────────────────────┼──────────────────┼─────────────────┤
  │                requests │              100 │               0 │
  ├─────────────────────────┼──────────────────┼─────────────────┤
  │            test-scripts │                0 │               0 │
  ├─────────────────────────┼──────────────────┼─────────────────┤
  │      prerequest-scripts │                0 │               0 │
  ├─────────────────────────┼──────────────────┼─────────────────┤
  │              assertions │                0 │               0 │
  ├─────────────────────────┴──────────────────┴─────────────────┤
  │ total run duration: 9.3s                                     │
  ├──────────────────────────────────────────────────────────────┤
  │ total data received: 13.6kB (approx)                         │
  ├──────────────────────────────────────────────────────────────┤
  │ average response time: 10ms [min: 5ms, max: 25ms, s.d.: 3ms] │
  └──────────────────────────────────────────────────────────────┘
  
  Postman CLI run data uploaded to Postman Cloud successfully.
  You can view the run data in Postman at: https://go.postman.co/workspace/16c09c1a-ff07-4b2d-87d4-83042d89bf8d/run/31716017-b2714039-d907-4602-955c-ceccb38eca5c
  
  stderr: ������ ��θ� ã�� �� �����ϴ�.
  
  Cleared all test data
  ```
- 현재 test data 삽입은 Users에 대해서만 되어 있는데 추후 다른 entity들에 대한 코드도 추가할 예정이다.

## 링크 (Links)
https://www.notion.so/do0ori/API-response-time-script-01930c284bd64a119b1a88da08085d5a

## 기타 사항 (Etc)
https://www.notion.so/do0ori/API-fe00bac8413446b3a29606673aa44826?pvs=4#79cbfca6ef164d909ebcdd3c64142f83

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
