### PR TITLE
backend/DANG-1104: getWalkDayList 함수에 walkDayIds 인자가 빈 배열일 경우에 대한  예외처리 추가

### DIFF
--- a/backend/src/dog-walk-day/dog-walk-day.service.spec.ts
+++ b/backend/src/dog-walk-day/dog-walk-day.service.spec.ts
@@ -49,22 +49,28 @@ describe('DogWalkDayService', () => {
             });
         });
 
-        context('올바른 값이 주어지지 않으면', () => {
+        context('빈 배열이 주어지면', () => {
             beforeEach(() => {
                 jest.spyOn(repository, 'find').mockResolvedValue([]);
             });
 
-            it('walkDayIds 배열이 비어있을 때 NotFoundException을 던져야 한다.', async () => {
+            it('NotFoundException을 던져야 한다.', async () => {
                 await expect(dogWalkDayService.getWalkDayList([])).rejects.toThrow(
                     new NotFoundException('walkDayIds에 값이 없습니다'),
                 );
             });
+        });
+    });
 
-            it('id가 존재하지 않을 때 NotFoundException 던져야 한다.', async () => {
-                await expect(dogWalkDayService.getWalkDayList([3, 4])).rejects.toThrow(
-                    new NotFoundException('id가 3,4인 레코드를 찾을 수 없습니다'),
-                );
-            });
+    context('존재하지 않는 id가 포함된 배열이 주어지면', () => {
+        beforeEach(() => {
+            jest.spyOn(repository, 'find').mockResolvedValue([]);
+        });
+
+        it('NotFoundException을 던져야 한다.', async () => {
+            await expect(dogWalkDayService.getWalkDayList([3, 4])).rejects.toThrow(
+                new NotFoundException('id가 3,4인 레코드를 찾을 수 없습니다'),
+            );
         });
     });
 

--- a/backend/src/dog-walk-day/dog-walk-day.service.spec.ts
+++ b/backend/src/dog-walk-day/dog-walk-day.service.spec.ts
@@ -54,9 +54,15 @@ describe('DogWalkDayService', () => {
                 jest.spyOn(repository, 'find').mockResolvedValue([]);
             });
 
-            it('NotFoundException 던져야 한다.', async () => {
+            it('walkDayIds 배열이 비어있을 때 NotFoundException을 던져야 한다.', async () => {
                 await expect(dogWalkDayService.getWalkDayList([])).rejects.toThrow(
-                    new NotFoundException('id가 인 레코드를 찾을 수 없습니다'),
+                    new NotFoundException('walkDayIds에 값이 없습니다'),
+                );
+            });
+
+            it('id가 존재하지 않을 때 NotFoundException 던져야 한다.', async () => {
+                await expect(dogWalkDayService.getWalkDayList([3, 4])).rejects.toThrow(
+                    new NotFoundException('id가 3,4인 레코드를 찾을 수 없습니다'),
                 );
             });
         });

--- a/backend/src/dog-walk-day/dog-walk-day.service.ts
+++ b/backend/src/dog-walk-day/dog-walk-day.service.ts
@@ -17,6 +17,11 @@ export class DogWalkDayService {
 
     async getWalkDayList(walkDayIds: number[]): Promise<number[][]> {
         const foundDays = await this.dogWalkDayRepository.find({ where: { id: In(walkDayIds) } });
+
+        if (!walkDayIds.length) {
+            this.logger.error(`walkDayIds에 값이 없습니다`, '');
+            throw new NotFoundException(`walkDayIds에 값이 없습니다`);
+        }
         if (!foundDays.length) {
             this.logger.error(`id가 ${walkDayIds}인 레코드를 찾을 수 없습니다`, '');
             throw new NotFoundException(`id가 ${walkDayIds}인 레코드를 찾을 수 없습니다`);

--- a/backend/src/dog-walk-day/dog-walk-day.service.ts
+++ b/backend/src/dog-walk-day/dog-walk-day.service.ts
@@ -16,12 +16,13 @@ export class DogWalkDayService {
     ) {}
 
     async getWalkDayList(walkDayIds: number[]): Promise<number[][]> {
-        const foundDays = await this.dogWalkDayRepository.find({ where: { id: In(walkDayIds) } });
-
         if (!walkDayIds.length) {
             this.logger.error(`walkDayIds에 값이 없습니다`, '');
             throw new NotFoundException(`walkDayIds에 값이 없습니다`);
         }
+
+        const foundDays = await this.dogWalkDayRepository.find({ where: { id: In(walkDayIds) } });
+
         if (!foundDays.length) {
             this.logger.error(`id가 ${walkDayIds}인 레코드를 찾을 수 없습니다`, '');
             throw new NotFoundException(`id가 ${walkDayIds}인 레코드를 찾을 수 없습니다`);


### PR DESCRIPTION
## 작업 내용 (Content)
getWalkDayList 함수에 walkDayIds 인자가 빈 배열일 경우에 대한  예외처리 추가하고
이에 대한 테스트 케이스를 추가했습니다.

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
