### PR TITLE
backend/DANG-1122: updateDurations 메서드 예외 처리 오류 수정

### DIFF
--- a/backend/src/today-walk-time/today-walk-time.service.spec.ts
+++ b/backend/src/today-walk-time/today-walk-time.service.spec.ts
@@ -103,8 +103,8 @@ describe('ExcrementsService', () => {
         context('존재하지 않는 walkTimeIds가 주어지면', () => {
             it('NotFoundException 예외를 던져야 한다.', async () => {
                 await expect(
-                    service.updateDurations([], 10, (current: number, operand: number) => current + operand),
-                ).rejects.toThrow(new NotFoundException('id: 와 일치하는 레코드가 없습니다'));
+                    service.updateDurations([99, 100], 10, (current: number, operand: number) => current + operand),
+                ).rejects.toThrow(new NotFoundException('id: 99,100와 일치하는 레코드가 없습니다'));
             });
         });
     });

--- a/backend/src/today-walk-time/today-walk-time.service.ts
+++ b/backend/src/today-walk-time/today-walk-time.service.ts
@@ -34,7 +34,7 @@ export class TodayWalkTimeService {
     ): Promise<void> {
         //TODO: batch 업데이트
         const todayWalkTimes = await this.findWalkTimesByIds(walkTimeIds);
-        if (!walkTimeIds.length) {
+        if (!todayWalkTimes.length) {
             const error = new NotFoundException(`id: ${walkTimeIds}와 일치하는 레코드가 없습니다`);
             this.logger.error(`id: ${walkTimeIds}와 일치하는 레코드가 없습니다`, {
                 trace: error.stack ?? '스택 없음',


### PR DESCRIPTION
## 작업 내용 (Content)
- updateDurations 메서드에서 todayWalkTimes 조회 결과가 비어있는 경우에만 예외 발생하도록 수정
- 예외 메시지에 누락된 walkTimeIds 정보 추가
- 테스트 케이스의 입력값 수정 (빈 배열 -> 존재하지 않는 walkTimeIds)
- 테스트 케이스의 예상 예외 메시지 수정

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
