### PR TITLE
backend/DANG-1125: getWalkDurations 테스트 케이스에 대한 repository.update 모킹 추가

### DIFF
--- a/backend/src/today-walk-time/today-walk-time.service.spec.ts
+++ b/backend/src/today-walk-time/today-walk-time.service.spec.ts
@@ -61,6 +61,7 @@ describe('ExcrementsService', () => {
     describe('getWalkDurations', () => {
         beforeEach(() => {
             jest.spyOn(todayWalkTimeRepository, 'find').mockImplementation(createMockFindImplementation());
+            jest.spyOn(todayWalkTimeRepository, 'update').mockResolvedValue({ affected: 1 } as UpdateResult);
         });
 
         context('특정 walkTimeIds가 주어지면', () => {


### PR DESCRIPTION
## 작업 내용 (Content)
- 기존 getWalkDurations 테스트 케이스에 누락되었던 todayWalkTimeRepository.update 메서드 모킹 추가
- 추후 getWalkDurations 테스트 케이스에 업데이트 로직이 추가될 경우를 대비하여 사전에 모킹 설정

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
