### PR TITLE
backend/DANG-1127: findOne 인자 타입 findOneOptions로 변경

### DIFF
--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -86,7 +86,7 @@ export class AuthService {
     }
 
     async logout({ userId, provider }: AccessTokenPayload): Promise<void> {
-        const { oauthAccessToken } = await this.usersService.findOne({ id: userId });
+        const { oauthAccessToken } = await this.usersService.findOne({ where: { id: userId } });
         this.logger.debug('logout - oauthAccessToken', { oauthAccessToken });
 
         if (provider === 'kakao') {
@@ -95,7 +95,7 @@ export class AuthService {
     }
 
     async reissueTokens({ oauthId, provider }: RefreshTokenPayload): Promise<AuthData> {
-        const { id: userId, oauthRefreshToken } = await this.usersService.findOne({ oauthId });
+        const { id: userId, oauthRefreshToken } = await this.usersService.findOne({ where: { oauthId } });
 
         // TODO: Promise.all로 병렬처리 한 후 성능 비교하기
         // const [
@@ -125,7 +125,7 @@ export class AuthService {
     }
 
     async deactivate({ userId, provider }: AccessTokenPayload): Promise<void> {
-        const { oauthAccessToken } = await this.usersService.findOne({ id: userId });
+        const { oauthAccessToken } = await this.usersService.findOne({ where: { id: userId } });
 
         if (provider === 'kakao') {
             await this.kakaoService.requestUnlink(oauthAccessToken);
@@ -154,7 +154,7 @@ export class AuthService {
         const payload = (await this.tokenService.verify(token)) as AccessTokenPayload;
         this.logger.log('Payload', payload);
 
-        const result = await this.usersService.findOne({ id: payload.userId });
+        const result = await this.usersService.findOne({ where: { id: payload.userId } });
         this.logger.debug('validateAccessToken - find User result', { ...result });
 
         return payload;
@@ -164,7 +164,7 @@ export class AuthService {
         const payload = (await this.tokenService.verify(token)) as RefreshTokenPayload;
         this.logger.log('Payload', payload);
 
-        const { refreshToken } = await this.usersService.findOne({ oauthId: payload.oauthId });
+        const { refreshToken } = await this.usersService.findOne({ where: { oauthId: payload.oauthId } });
 
         if (refreshToken !== token) {
             throw new UnauthorizedException();

--- a/backend/src/breed/breed.service.spec.ts
+++ b/backend/src/breed/breed.service.spec.ts
@@ -39,7 +39,7 @@ describe('BreedService', () => {
             });
 
             it('견종 정보를 반환해야 한다.', async () => {
-                const breed = await service.findOne({ id: 1 });
+                const breed = await service.findOne({ where: { id: 1 } });
 
                 expect(breed).toEqual({
                     id: 1,

--- a/backend/src/breed/breed.service.ts
+++ b/backend/src/breed/breed.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { FindOptionsWhere, In } from 'typeorm';
+import { FindOneOptions, In } from 'typeorm';
 
 import { Breed } from './breed.entity';
 import { BreedRepository } from './breed.repository';
@@ -8,7 +8,7 @@ import { BreedRepository } from './breed.repository';
 export class BreedService {
     constructor(private readonly breedRepository: BreedRepository) {}
 
-    async findOne(where: FindOptionsWhere<Breed>): Promise<Breed> {
+    async findOne(where: FindOneOptions<Breed>): Promise<Breed> {
         return this.breedRepository.findOne(where);
     }
 

--- a/backend/src/common/database/abstract.repository.ts
+++ b/backend/src/common/database/abstract.repository.ts
@@ -3,6 +3,7 @@ import {
     DeleteResult,
     EntityManager,
     FindManyOptions,
+    FindOneOptions,
     FindOptionsWhere,
     ObjectLiteral,
     Repository,
@@ -49,8 +50,8 @@ export abstract class AbstractRepository<T extends ObjectLiteral> {
         return this.entityRepository.findOne({ where });
     }
 
-    async findOne(where: FindOptionsWhere<T>): Promise<T> {
-        const entity = await this.entityRepository.findOne({ where });
+    async findOne(where: FindOneOptions<T>): Promise<T> {
+        const entity = await this.entityRepository.findOne(where);
 
         if (!entity) {
             throw new NotFoundException('findOne: Entity not found');
@@ -89,7 +90,8 @@ export abstract class AbstractRepository<T extends ObjectLiteral> {
         if (!updateResult.affected) {
             throw new NotFoundException('update: Entity not found');
         }
+        const options: FindOneOptions = { where };
 
-        return this.findOne(where);
+        return this.findOne(options);
     }
 }

--- a/backend/src/dog-walk-day/dog-walk-day.service.ts
+++ b/backend/src/dog-walk-day/dog-walk-day.service.ts
@@ -44,7 +44,7 @@ export class DogWalkDayService {
 
         //TODO: for 문을 안 쓰는 방향으로..? batch 업데이트? 알고리즘까지.. (log N -> 상수시간?)
         for (const dogWalkDayId of dogWalkDayIds) {
-            const findDogWalkDay = await this.dogWalkDayRepository.findOne({ id: dogWalkDayId });
+            const findDogWalkDay = await this.dogWalkDayRepository.findOne({ where: { id: dogWalkDayId } });
             const dogWalkDayCount = findDogWalkDay[day] as number;
             const updateCount = operation(dogWalkDayCount);
 

--- a/backend/src/dogs/dogs.service.ts
+++ b/backend/src/dogs/dogs.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { EntityManager, FindOptionsWhere, In } from 'typeorm';
+import { EntityManager, FindOneOptions, FindOptionsWhere, In } from 'typeorm';
 import { Transactional } from 'typeorm-transactional';
 
 import { Dogs } from './dogs.entity';
@@ -39,7 +39,7 @@ export class DogsService {
         try {
             const { breed: breedName, ...otherAttributes } = dogDto;
 
-            const breed = await this.breedService.findOne({ koreanName: breedName });
+            const breed = await this.breedService.findOne({ where: { koreanName: breedName } });
 
             const newDog = new Dogs({
                 breed,
@@ -60,7 +60,7 @@ export class DogsService {
     //TODO: Promise all 사용하여 병렬적으로 삭제 쿼리 날리기
     @Transactional()
     async deleteDogFromUser(userId: number, dogId: number) {
-        const dog = await this.dogsRepository.findOne({ id: dogId });
+        const dog = await this.dogsRepository.findOne({ where: { id: dogId } });
 
         await this.dogWalkDayService.delete({ id: dog.walkDayId });
         await this.todayWalkTimeService.delete({ id: dog.todayWalkTimeId });
@@ -71,7 +71,7 @@ export class DogsService {
         return dog;
     }
 
-    async findOne(where: FindOptionsWhere<Dogs>) {
+    async findOne(where: FindOneOptions<Dogs>) {
         return this.dogsRepository.findOne(where);
     }
 
@@ -80,11 +80,11 @@ export class DogsService {
         let breed;
 
         if (breedName) {
-            breed = await this.breedService.findOne({ koreanName: breedName });
+            breed = await this.breedService.findOne({ where: { koreanName: breedName } });
         }
 
         if (dogDto.profilePhotoUrl) {
-            const curDogInfo = await this.dogsRepository.findOne({ id: dogId });
+            const curDogInfo = await this.dogsRepository.findOne({ where: { id: dogId } });
             if (curDogInfo && curDogInfo.profilePhotoUrl) {
                 await this.s3Service.deleteSingleObject(userId, curDogInfo.profilePhotoUrl);
             }
@@ -131,7 +131,7 @@ export class DogsService {
 
     //TODO : makeProfile 함수로 하지 않고 애초에 select 해서 가져오기
     async getProfile(dogId: number): Promise<DogProfile> {
-        const dogInfo = await this.dogsRepository.findOne({ id: dogId });
+        const dogInfo = await this.dogsRepository.findOne({ where: { id: dogId } });
         return this.makeProfile(dogInfo);
     }
 

--- a/backend/src/journals/journals.service.ts
+++ b/backend/src/journals/journals.service.ts
@@ -73,7 +73,7 @@ export class JournalsService {
 
     //TODO: select 적용하기
     async getJournalInfoForDetail(journalId: number): Promise<JournalInfoForDetail> {
-        const journalInfoRaw = await this.journalsRepository.findOne({ id: journalId });
+        const journalInfoRaw = await this.journalsRepository.findOne({ where: { id: journalId } });
         const journalInfo = makeSubObject(journalInfoRaw, JournalInfoForDetail.getKeysForJournalTable());
         journalInfo.id = journalId;
         journalInfo.routes = JSON.parse(journalInfo.routes);
@@ -100,7 +100,7 @@ export class JournalsService {
     }
 
     async getDogsInfoForDetail(dogId: number): Promise<DogInfoForDetail> {
-        const dogInfoRaw = await this.dogsService.findOne({ id: dogId });
+        const dogInfoRaw = await this.dogsService.findOne({ where: { id: dogId } });
         //TODO: select로 바꾸기
         const dogInfo: DogInfoForDetail = makeSubObject(dogInfoRaw, DogInfoForDetail.getKeysForDogTable());
 
@@ -235,7 +235,7 @@ export class JournalsService {
     async deleteJournal(userId: number, journalId: number) {
         const photoUrls: string[] = await this.journalPhotosService.getPhotoUrlsByJournalId(journalId);
         const dogIds: number[] = await this.journalsDogsService.getDogIdsByJournalId(journalId);
-        const journalInfo = await this.journalsRepository.findOne({ id: journalId });
+        const journalInfo = await this.journalsRepository.findOne({ where: { id: journalId } });
 
         //TODO: promise-all로 병렬 처리하기
         await this.updateDogWalkDay(dogIds, (current: number) => (current -= 1));

--- a/backend/src/users-dogs/users-dogs.service.ts
+++ b/backend/src/users-dogs/users-dogs.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { FindOptionsWhere } from 'typeorm';
+import { FindManyOptions } from 'typeorm';
 
 import { UsersDogs } from './users-dogs.entity';
 import { UsersDogsRepository } from './users-dogs.repository';
@@ -13,7 +13,7 @@ export class UsersDogsService {
         return this.usersDogsRepository.create(userDog);
     }
 
-    async find(where: FindOptionsWhere<UsersDogs>) {
-        return this.usersDogsRepository.find({ where });
+    async find(where: FindManyOptions<UsersDogs>) {
+        return this.usersDogsRepository.find(where);
     }
 }

--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -58,7 +58,7 @@ describe('UsersService', () => {
             });
 
             it('사용자 정보를 반환해야 한다.', async () => {
-                const res = await service.findOne({ id: mockUser.id });
+                const res = await service.findOne({ where: { id: mockUser.id } });
 
                 expect(res).toEqual(mockUser);
             });
@@ -70,7 +70,7 @@ describe('UsersService', () => {
             });
 
             it('NotFoundException 예외를 던져야 한다.', async () => {
-                await expect(service.findOne({ id: 1 })).rejects.toThrow(NotFoundException);
+                await expect(service.findOne({ where: { id: 1 } })).rejects.toThrow(NotFoundException);
             });
         });
     });

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { FindOptionsWhere } from 'typeorm';
+import { FindOneOptions, FindOptionsWhere } from 'typeorm';
 import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
 
 import { CreateUser } from './types/create-user.type';
@@ -23,7 +23,7 @@ export class UsersService {
         private readonly s3Service: S3Service,
     ) {}
 
-    async findOne(where: FindOptionsWhere<Users>) {
+    async findOne(where: FindOneOptions<Users>) {
         return this.usersRepository.findOne(where);
     }
 
@@ -81,7 +81,7 @@ export class UsersService {
 
     async getUserProfile({ userId, provider }: AccessTokenPayload): Promise<UserProfile> {
         //TODO: select로 변경
-        const { nickname, email, profileImageUrl } = await this.usersRepository.findOne({ id: userId });
+        const { nickname, email, profileImageUrl } = await this.usersRepository.findOne({ where: { id: userId } });
         return { nickname, email, profileImageUrl, provider };
     }
 
@@ -94,7 +94,7 @@ export class UsersService {
         }
 
         if (profileImageUrl) {
-            const curUserInfo = await this.usersRepository.findOne({ id: userId });
+            const curUserInfo = await this.usersRepository.findOne({ where: { id: userId } });
             if (curUserInfo && curUserInfo.profileImageUrl) {
                 await this.s3Service.deleteSingleObject(userId, curUserInfo.profileImageUrl);
             }

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -67,13 +67,13 @@ export class UsersService {
 
     async getOwnDogsList(userId: number): Promise<number[]> {
         //TODO: select로 변경
-        const foundDogs = await this.usersDogsService.find({ userId });
+        const foundDogs = await this.usersDogsService.find({ where: { userId } });
         return foundDogs.map((cur) => cur.dogId);
     }
 
     async checkDogOwnership(userId: number, dogId: number | number[]): Promise<[boolean, number[]]> {
         //TODO: select로 변경
-        const ownDogs = await this.usersDogsService.find({ userId });
+        const ownDogs = await this.usersDogsService.find({ where: { userId } });
         const myDogIds = ownDogs.map((cur) => cur.dogId);
 
         return checkIfExistsInArr(myDogIds, dogId);

--- a/backend/src/walk/walk.service.ts
+++ b/backend/src/walk/walk.service.ts
@@ -24,7 +24,7 @@ export class WalkService {
     protected async checkAvailableDogs(dogIds: number[]) {
         //TODO: batch 로 변경 for문 없애기
         for (const curDogId of dogIds) {
-            const curDogInfo = await this.dogsService.findOne({ id: curDogId });
+            const curDogInfo = await this.dogsService.findOne({ where: { id: curDogId } });
             const updatedAt = curDogInfo.updatedAt;
             const curTime = new Date();
 


### PR DESCRIPTION
## 작업 내용 (Content)
- findOne에 select 옵션을 사용하기 위해, where 뿐만 아니라  여러 옵션을 포괄하는 findOneOptions 타입으로 인자의 타입을 변경하였습니다.

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
