### PR TITLE
backend/DANG-1105: n명의 사용자에게 0~5마리의 강아지를 random하게 생성하는 로직 추가

### DIFF
--- a/backend/test/performance/utils/createMockEntity.util.ts
+++ b/backend/test/performance/utils/createMockEntity.util.ts
@@ -1,0 +1,64 @@
+import * as fs from 'node:fs';
+
+import { getRandomInt, getRandomPastDate } from './random.util';
+
+import { DogWalkDay } from '../../../src/dog-walk-day/dog-walk-day.entity';
+import { Dogs } from '../../../src/dogs/dogs.entity';
+import { GENDER } from '../../../src/dogs/types/gender.type';
+import { TodayWalkTime } from '../../../src/today-walk-time/today-walk-time.entity';
+import { ROLE } from '../../../src/users/types/role.type';
+import { Users } from '../../../src/users/users.entity';
+import { UsersDogs } from '../../../src/users-dogs/users-dogs.entity';
+import { formatDate } from '../../../src/utils/date.util';
+import { generateUuid } from '../../../src/utils/hash.util';
+import { OAUTH_ACCESS_TOKEN, OAUTH_REFRESH_TOKEN, VALID_REFRESH_TOKEN_100_YEARS } from '../../constants';
+
+export function createMockUsers(n: number): Users[] {
+    return Array(n)
+        .fill(undefined)
+        .map(
+            (_, i) =>
+                new Users({
+                    nickname: `${i + 1}#${generateUuid()}`,
+                    email: `test${i + 1}@mail.com`,
+                    profileImageUrl: 'default/profile.png',
+                    role: ROLE.User,
+                    mainDogId: null,
+                    oauthId: (i + 1).toString(),
+                    oauthAccessToken: OAUTH_ACCESS_TOKEN,
+                    oauthRefreshToken: OAUTH_REFRESH_TOKEN,
+                    refreshToken: VALID_REFRESH_TOKEN_100_YEARS,
+                }),
+        );
+}
+
+export function createMockDogsForUsers(users: Users[]): [Dogs[], UsersDogs[]] {
+    const breedData = JSON.parse(fs.readFileSync('resources/breedData.json', 'utf-8'));
+    const breedsLength = breedData.length;
+    const dogs: Dogs[] = [];
+    const usersDogs: UsersDogs[] = [];
+
+    users.forEach((_, index) => {
+        const numberOfDogs = getRandomInt(0, 5);
+
+        for (let i = 0; i < numberOfDogs; i++) {
+            const dog = new Dogs({
+                walkDay: new DogWalkDay(),
+                todayWalkTime: new TodayWalkTime(),
+                name: `강아지 ${dogs.length + 1}`,
+                breedId: getRandomInt(1, breedsLength),
+                gender: Math.random() < 0.5 ? GENDER.Male : GENDER.Female,
+                birth: Math.random() < 0.5 ? null : formatDate(getRandomPastDate(365 * 15)),
+                isNeutered: Math.random() < 0.5,
+                weight: getRandomInt(1, 50),
+                profilePhotoUrl: 'mock_profile_photo.jpg',
+                isWalking: false,
+            });
+
+            dogs.push(dog);
+            usersDogs.push(new UsersDogs({ userId: index + 1, dogId: dogs.length }));
+        }
+    });
+
+    return [dogs, usersDogs];
+}

--- a/backend/test/performance/utils/random.util.ts
+++ b/backend/test/performance/utils/random.util.ts
@@ -1,0 +1,13 @@
+export function getRandomInt(min: number, max: number): number {
+    return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+export function getRandomDate(start: Date, end: Date): Date {
+    return new Date(start.getTime() + Math.random() * (end.getTime() - start.getTime()));
+}
+
+// 현재 날짜를 기준으로 과거의 랜덤한 날짜 생성
+export function getRandomPastDate(days: number): Date {
+    const now = new Date();
+    return getRandomDate(new Date(now.getTime() - days * 24 * 60 * 60 * 1000), now);
+}


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- utils에 random한 값을 반환하는 함수들과 mock entity들을 생성하는 함수들을 정의하였다.
- n명의 사용자에게 0~5마리의 강아지를 random하게 생성한다.
- postman을 사용하지 않고 data만 넣어본 예시! 잘 된다. 😄
  ```
  $ npm run test:response-time
  
  > nest-js-example@0.0.1 test:response-time
  > cross-env NODE_ENV=test ts-node ./test/performance/response-time.ts
  
  Test server running at http://localhost:3333
  Successfully inserted test data:
  ┌─────────┬────────────┬───────┐
  │ (index) │   Entity   │ Count │
  ├─────────┼────────────┼───────┤
  │    0    │  'Users'   │  10   │
  │    1    │   'Dogs'   │  25   │
  │    2    │ 'UserDogs' │  25   │
  └─────────┴────────────┴───────┘
  Cleared all test data
  ```

## 링크 (Links)
https://www.notion.so/do0ori/API-response-time-script-insertTestData-a62c7f9285984b8893c6656fe0d4ca53

## 기타 사항 (Etc)
data 삽입/삭제만 따로 사용할 수 있게 분리하는 것도 좋을 것 같다.

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
