### PR TITLE
backend/DANG-1134: Breed TODO select 추가 & 성능 개선 및 측정

### DIFF
--- a/backend/src/breed/breed.service.ts
+++ b/backend/src/breed/breed.service.ts
@@ -14,6 +14,7 @@ export class BreedService {
 
     async getKoreanNames(): Promise<string[]> {
         const breeds = await this.breedRepository.find({ select: ['koreanName'] });
+
         if (!breeds.length) {
             throw new NotFoundException(`견종 목록을 찾을 수 없습니다.`);
         }
@@ -22,8 +23,10 @@ export class BreedService {
     }
 
     async getRecommendedWalkAmountList(breedIds: number[]): Promise<number[]> {
-        //TODO: select 조건 걸기, 리팩토링
-        const breeds = await this.breedRepository.find({ where: { id: In(breedIds) } });
+        const breeds = await this.breedRepository.find({
+            where: { id: In(breedIds) },
+            select: ['id', 'recommendedWalkAmount'],
+        });
 
         if (!breeds.length) {
             throw new NotFoundException(`${breedIds} 해당 견종을 찾을 수 없습니다.`);


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- breed service에서 select로 필요한 column만 반환하도록 추가
- breed table의 koreanName에 index를 추가할까 했지만 실제로 해본 결과 217개 밖에 안되는 너무 작은 table이라 개선 정도가 너무 미미해서 추가하지 않았다.

## 링크 (Links)

## 기타 사항 (Etc)
select를 추가한 것만으로는 개선 정도가 미미했지만 성능 측정에 익숙해져 보고자 연습 겸 해보았다.
https://www.notion.so/do0ori/select-182d25d12f67425d8f4bcf70e29ce25c
제대로 측정을 한 것인지 한번 읽어보시고 피드백 주시면 감사하겠습니다. 😄

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
