### PR TITLE
backend/DANG-1139: 최근 한달 간 산책 통계 API period query validation 수정

### DIFF
--- a/backend/src/statistics/pipes/period-validation.pipe.ts
+++ b/backend/src/statistics/pipes/period-validation.pipe.ts
@@ -1,11 +1,14 @@
 import { BadRequestException, Injectable, PipeTransform } from '@nestjs/common';
 
-const allowedPeriods = ['month', 'week'] as const;
-export type Period = (typeof allowedPeriods)[number];
+export type Period = 'month' | 'week';
 
 @Injectable()
 export class PeriodValidationPipe implements PipeTransform<Period, Period> {
-    readonly allowedPeriods = allowedPeriods;
+    private readonly allowedPeriods;
+
+    constructor(allowedPeriods: Period[]) {
+        this.allowedPeriods = allowedPeriods;
+    }
 
     transform(value: Period): Period {
         if (!value) {

--- a/backend/src/statistics/statistics.controller.ts
+++ b/backend/src/statistics/statistics.controller.ts
@@ -19,7 +19,7 @@ export class StatisticsController {
     async getDogStatistics(
         @User() { userId }: AccessTokenPayload,
         @Param('id', ParseIntPipe) dogId: number,
-        @Query('period', PeriodValidationPipe) period: Period,
+        @Query('period', new PeriodValidationPipe(['month'])) period: Period,
     ) {
         return await this.statisticsService.getDogStatistics(userId, dogId, period);
     }
@@ -30,7 +30,7 @@ export class StatisticsController {
         @User() { userId }: AccessTokenPayload,
         @Param('id', ParseIntPipe) dogId: number,
         @Query('date', DateValidationPipe) date: string,
-        @Query('period', PeriodValidationPipe) period: Period,
+        @Query('period', new PeriodValidationPipe(['month', 'week'])) period: Period,
     ) {
         return await this.statisticsService.getDogWalkCnt(userId, dogId, date, period);
     }

--- a/backend/test/statistics.e2e-spec.ts
+++ b/backend/test/statistics.e2e-spec.ts
@@ -197,6 +197,13 @@ describe('StatisticsController (e2e)', () => {
                     .set('Authorization', `Bearer ${VALID_ACCESS_TOKEN_100_YEARS}`)
                     .expect(400);
             });
+
+            it('400 상태 코드를 반환해야 한다.', () => {
+                return request(app.getHttpServer())
+                    .get('/dogs/1/statistics/recent?period=week')
+                    .set('Authorization', `Bearer ${VALID_ACCESS_TOKEN_100_YEARS}`)
+                    .expect(400);
+            });
         });
 
         testUnauthorizedAccess('강아지의 최근 한달 간 산책 통계 조회', 'get', '/dogs/1/statistics/recent?period=month');


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- 현재 최근 한달 간 산책 통계 API만 존재하기 때문에  `PeriodValidationPipe`에서 동적으로 period 값을 받도록 수정했다.
- statistics e2e test에 period query가 week인 test case 추가 (`period=week`)

## 링크 (Links)
https://www.notion.so/do0ori/API-period-query-validation-caca888003fc413fab1cd827e82b86ef

## 기타 사항 (Etc)
https://github.com/dangdangwalk/dangdang-walk/pull/790#discussion_r1653181712

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
