### PR TITLE
backend/DANG-1141: query logger 개선

### DIFF
--- a/backend/src/common/database/database.module.ts
+++ b/backend/src/common/database/database.module.ts
@@ -27,8 +27,7 @@ import { WinstonLoggerService } from '../logger/winstonLogger.service';
             inject: [ConfigService],
             useFactory: (config: ConfigService) => {
                 const nodeEnv = config.get<string>('NODE_ENV');
-                const isTest = nodeEnv === 'test';
-                const isLocal = nodeEnv === 'local';
+                const enableQueryLogger = config.get<boolean>('ENABLE_QUERY_LOGGER');
 
                 return {
                     type: 'mysql',
@@ -52,7 +51,7 @@ import { WinstonLoggerService } from '../logger/winstonLogger.service';
                     synchronize: true,
                     timezone: 'Z',
                     legacySpatialSupport: false,
-                    ...(isTest || isLocal
+                    ...(enableQueryLogger
                         ? { logger: new FileLogger(true, { logPath: `log/ormlogs.${nodeEnv}.log` }) }
                         : {}),
                 };

--- a/backend/src/common/interceptors/profilingInterceptor.ts
+++ b/backend/src/common/interceptors/profilingInterceptor.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs';
 
 import { CallHandler, ExecutionContext, Inject, Injectable, NestInterceptor } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { getDataSourceToken } from '@nestjs/typeorm';
 import { Observable, from } from 'rxjs';
 import { map, switchMap } from 'rxjs/operators';
@@ -8,7 +9,10 @@ import { DataSource } from 'typeorm';
 
 @Injectable()
 export class ProfilingInterceptor implements NestInterceptor {
-    constructor(@Inject(getDataSourceToken()) private readonly dataSource: DataSource) {}
+    constructor(
+        @Inject(getDataSourceToken()) private readonly dataSource: DataSource,
+        private readonly configService: ConfigService,
+    ) {}
 
     intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
         const originUrl = context.switchToHttp().getRequest().url.toString();
@@ -30,20 +34,17 @@ export class ProfilingInterceptor implements NestInterceptor {
 
     private async logProfilingData(method: string, originUrl: string, startTime: number): Promise<void> {
         const duration = Date.now() - startTime;
+        const timestamp = new Date().toLocaleString();
 
         const profiles = await this.dataSource.query('SHOW PROFILES');
-        const profileDetailsPromises = profiles.map((profile: any) =>
-            this.dataSource.query(`SHOW PROFILE FOR QUERY ${profile.Query_ID}`),
-        );
-        const profileDetails = await Promise.all(profileDetailsPromises);
-        const profilesWithDetails = profiles.map((profile: any, index: number) => ({
-            ...profile,
-            Details: profileDetails[index],
+        const queryDurations = profiles.map((profile: any) => ({
+            Query: profile.Query,
+            Duration: profile.Duration,
         }));
 
         fs.appendFileSync(
-            'log/query-profiling.log',
-            `>> ${method} ${originUrl}\nAPI Call Duration: ${duration}ms\nProfiles: ${JSON.stringify(profilesWithDetails, null, 2)}\n\n`,
+            `log/query-profiling.${this.configService.get<string>('NODE_ENV')}.log`,
+            `>> ${method} ${originUrl}\nTimestamp: ${timestamp}\nAPI Call Duration: ${duration}ms\nExecuted Queries: ${queryDurations.length}\nQueries: ${JSON.stringify(queryDurations, null, 2)}\n\n`,
         );
     }
 


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- 기존 typeorm의 query log는 환경 변수 `ENABLE_QUERY_LOGGER` 값이 true인 경우에만 사용하도록 했다.
- ProfilingInterceptor에서 Query Id와 detail 정보를 삭제하고 timestamp와 실행한 총 query 개수, query 별 실행 시간을 기록하도록 수정했다. log도 환경 별로 찍힌다.
- 기존 orm log는 모든 query가 기록되는 반면 profiling log는 요청마다 실행된 query만 기록된다. 필요한 정보에 맞게 선택적으로 사용하면 된다.
 
## 링크 (Links)
https://www.notion.so/do0ori/query-logger-809e98fdbd0249bda3d9c71eed6cb52c

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?