### PR TITLE
backend/DANG-1143: API response time script의 insertTestData 함수에 일지 추가

### DIFF
--- a/backend/test/performance/response-time.ts
+++ b/backend/test/performance/response-time.ts
@@ -64,7 +64,7 @@ export const closeTestApp = async () => {
 };
 
 export const insertTestData = async (n: number): Promise<void> => {
-    await dataSource.query('SET FOREIGN_KEY_CHECKS = 0;');
+    await dataSource.query('SET GLOBAL FOREIGN_KEY_CHECKS = 0;');
 
     const mockEntityCreator = new CreateMockEntity(dataSource, n);
 
@@ -81,7 +81,7 @@ export const insertTestData = async (n: number): Promise<void> => {
 
     console.log(`Successfully inserted test data (${color(`+${duration}ms`, 'Cyan')}):`);
 
-    await dataSource.query('SET FOREIGN_KEY_CHECKS = 1;');
+    await dataSource.query('SET GLOBAL FOREIGN_KEY_CHECKS = 1;');
 
     const table = [...userResults, ...dogResults, ...journalResults];
     const totalSize = table.reduce((count, entity) => count + entity.Count, 0);

--- a/backend/test/performance/response-time.ts
+++ b/backend/test/performance/response-time.ts
@@ -64,18 +64,24 @@ export const closeTestApp = async () => {
 };
 
 export const insertTestData = async (n: number): Promise<void> => {
+    await dataSource.query('SET FOREIGN_KEY_CHECKS = 0;');
+
     const mockEntityCreator = new CreateMockEntity(dataSource, n);
 
     const startTime = Date.now();
 
-    const userResults = await mockEntityCreator.createMockUsers();
-    const dogResults = await mockEntityCreator.createMockDogs();
+    const [userResults, dogResults] = await Promise.all([
+        mockEntityCreator.createMockUsers(),
+        mockEntityCreator.createMockDogs(),
+    ]);
     const journalResults = await mockEntityCreator.createMockJournals();
 
     const endTime = Date.now();
     const duration = endTime - startTime;
 
     console.log(`Successfully inserted test data (${color(`+${duration}ms`, 'Cyan')}):`);
+
+    await dataSource.query('SET FOREIGN_KEY_CHECKS = 1;');
 
     const table = [...userResults, ...dogResults, ...journalResults];
     const totalSize = table.reduce((count, entity) => count + entity.Count, 0);

--- a/backend/test/performance/utils/createMockEntity.util.ts
+++ b/backend/test/performance/utils/createMockEntity.util.ts
@@ -59,7 +59,12 @@ export class CreateMockEntity {
                 }),
         );
 
-        await this.dataSource.getRepository(Users).save(this.users);
+        await this.dataSource
+            .createQueryBuilder(Users, 'users')
+            .insert()
+            .values(this.users)
+            .updateEntity(false)
+            .execute();
 
         return [{ Entity: 'Users', Count: this.users.length }];
     }
@@ -73,8 +78,8 @@ export class CreateMockEntity {
 
             for (let i = 0; i < numberOfDogs; i++) {
                 const dog = new Dogs({
-                    walkDay: new DogWalkDay(),
-                    todayWalkTime: new TodayWalkTime(),
+                    walkDayId: this.dogs.length + 1,
+                    todayWalkTimeId: this.dogs.length + 1,
                     name: `test-dog${this.dogs.length + 1}`,
                     breedId: getRandomInt({ min: 1, max: breedsLength }),
                     gender: GENDER.Male,
@@ -90,8 +95,25 @@ export class CreateMockEntity {
             }
         }
 
-        await this.dataSource.getRepository(Dogs).save(this.dogs);
-        await this.dataSource.getRepository(UsersDogs).save(this.usersDogs);
+        await this.dataSource.createQueryBuilder(Dogs, 'dogs').insert().values(this.dogs).updateEntity(false).execute();
+        await this.dataSource
+            .createQueryBuilder(UsersDogs, 'usersDogs')
+            .insert()
+            .values(this.usersDogs)
+            .updateEntity(false)
+            .execute();
+        await this.dataSource
+            .createQueryBuilder(DogWalkDay, 'dogWalkDay')
+            .insert()
+            .values(Array(this.n).fill(new DogWalkDay()))
+            .updateEntity(false)
+            .execute();
+        await this.dataSource
+            .createQueryBuilder(TodayWalkTime, 'todayWalkTime')
+            .insert()
+            .values(Array(this.n).fill(new TodayWalkTime()))
+            .updateEntity(false)
+            .execute();
 
         return [
             { Entity: 'Dogs', Count: this.dogs.length },
@@ -154,10 +176,10 @@ export class CreateMockEntity {
             }
         }
 
-        await this.dataSource.getRepository(Journals).save(this.journals);
-        await this.dataSource.getRepository(JournalsDogs).save(this.journalsDogs);
-        await this.dataSource.getRepository(JournalPhotos).save(this.journalPhotos);
-        await this.dataSource.getRepository(Excrements).save(this.excrements);
+        await this.dataSource.getRepository(Journals).insert(this.journals);
+        await this.dataSource.getRepository(JournalsDogs).insert(this.journalsDogs);
+        await this.dataSource.getRepository(JournalPhotos).insert(this.journalPhotos);
+        await this.dataSource.getRepository(Excrements).insert(this.excrements);
 
         return [
             { Entity: 'Journals', Count: this.journals.length },

--- a/backend/test/performance/utils/createMockEntity.util.ts
+++ b/backend/test/performance/utils/createMockEntity.util.ts
@@ -2,8 +2,6 @@ import * as fs from 'node:fs';
 
 import { DataSource } from 'typeorm';
 
-import { Transactional } from 'typeorm-transactional';
-
 import { getObjectValue, getRandomElements, getRandomInt, getRandomPastDate } from './random.util';
 
 import { DogWalkDay } from '../../../src/dog-walk-day/dog-walk-day.entity';
@@ -45,31 +43,27 @@ export class CreateMockEntity {
         private readonly n: number,
     ) {}
 
-    @Transactional()
     async createMockUsers(): Promise<ConsoleTableRowFormat[]> {
-        this.users = Array(this.n)
-            .fill(undefined)
-            .map(
-                (_, i) =>
-                    new Users({
-                        nickname: `test-user${i + 1}#${generateUuid()}`,
-                        email: `test-user${i + 1}@mail.com`,
-                        profileImageUrl: 'default/profile.png',
-                        role: ROLE.User,
-                        mainDogId: null,
-                        oauthId: (i + 1).toString(),
-                        oauthAccessToken: OAUTH_ACCESS_TOKEN,
-                        oauthRefreshToken: OAUTH_REFRESH_TOKEN,
-                        refreshToken: VALID_REFRESH_TOKEN_100_YEARS,
-                    }),
-            );
+        this.users = Array.from({ length: this.n }).map(
+            (_, i) =>
+                new Users({
+                    nickname: `test-user${i + 1}#${generateUuid()}`,
+                    email: `test-user${i + 1}@mail.com`,
+                    profileImageUrl: 'default/profile.png',
+                    role: ROLE.User,
+                    mainDogId: null,
+                    oauthId: (i + 1).toString(),
+                    oauthAccessToken: OAUTH_ACCESS_TOKEN,
+                    oauthRefreshToken: OAUTH_REFRESH_TOKEN,
+                    refreshToken: VALID_REFRESH_TOKEN_100_YEARS,
+                }),
+        );
 
         await this.dataSource.getRepository(Users).save(this.users);
 
         return [{ Entity: 'Users', Count: this.users.length }];
     }
 
-    @Transactional()
     async createMockDogs(): Promise<ConsoleTableRowFormat[]> {
         const breedData = JSON.parse(fs.readFileSync('resources/breedData.json', 'utf-8'));
         const breedsLength = breedData.length;
@@ -114,7 +108,6 @@ export class CreateMockEntity {
             .getRawMany();
     }
 
-    @Transactional()
     async createMockJournals() {
         const usersWithDogs = await this.getUsersWithDogs();
 

--- a/backend/test/performance/utils/createMockEntity.util.ts
+++ b/backend/test/performance/utils/createMockEntity.util.ts
@@ -1,10 +1,19 @@
 import * as fs from 'node:fs';
 
-import { getRandomInt } from './random.util';
+import { DataSource } from 'typeorm';
+
+import { Transactional } from 'typeorm-transactional';
+
+import { getObjectValue, getRandomElements, getRandomInt, getRandomPastDate } from './random.util';
 
 import { DogWalkDay } from '../../../src/dog-walk-day/dog-walk-day.entity';
 import { Dogs } from '../../../src/dogs/dogs.entity';
 import { GENDER } from '../../../src/dogs/types/gender.type';
+import { Excrements } from '../../../src/excrements/excrements.entity';
+import { EXCREMENT } from '../../../src/excrements/types/excrement.type';
+import { JournalPhotos } from '../../../src/journal-photos/journal-photos.entity';
+import { Journals } from '../../../src/journals/journals.entity';
+import { JournalsDogs } from '../../../src/journals-dogs/journals-dogs.entity';
 import { TodayWalkTime } from '../../../src/today-walk-time/today-walk-time.entity';
 import { ROLE } from '../../../src/users/types/role.type';
 import { Users } from '../../../src/users/users.entity';
@@ -12,52 +21,156 @@ import { UsersDogs } from '../../../src/users-dogs/users-dogs.entity';
 import { generateUuid } from '../../../src/utils/hash.util';
 import { OAUTH_ACCESS_TOKEN, OAUTH_REFRESH_TOKEN, VALID_REFRESH_TOKEN_100_YEARS } from '../../constants';
 
-export function createMockUsers(n: number): Users[] {
-    return Array(n)
-        .fill(undefined)
-        .map(
-            (_, i) =>
-                new Users({
-                    nickname: `test-user${i + 1}#${generateUuid()}`,
-                    email: `test-user${i + 1}@mail.com`,
-                    profileImageUrl: 'default/profile.png',
-                    role: ROLE.User,
-                    mainDogId: null,
-                    oauthId: (i + 1).toString(),
-                    oauthAccessToken: OAUTH_ACCESS_TOKEN,
-                    oauthRefreshToken: OAUTH_REFRESH_TOKEN,
-                    refreshToken: VALID_REFRESH_TOKEN_100_YEARS,
-                }),
-        );
+interface ConsoleTableRowFormat {
+    Entity: string;
+    Count: number;
 }
 
-export function createMockDogsForUsers(users: Users[]): [Dogs[], UsersDogs[]] {
-    const breedData = JSON.parse(fs.readFileSync('resources/breedData.json', 'utf-8'));
-    const breedsLength = breedData.length;
-    const dogs: Dogs[] = [];
-    const usersDogs: UsersDogs[] = [];
+interface UserWithDogs {
+    userId: number;
+    dogIds: number[];
+}
 
-    users.forEach((_, index) => {
-        const numberOfDogs = getRandomInt({ max: 5 });
+export class CreateMockEntity {
+    users: Users[] = [];
+    dogs: Dogs[] = [];
+    usersDogs: UsersDogs[] = [];
+    journals: Journals[] = [];
+    journalsDogs: JournalsDogs[] = [];
+    journalPhotos: JournalPhotos[] = [];
+    excrements: Excrements[] = [];
 
-        for (let i = 0; i < numberOfDogs; i++) {
-            const dog = new Dogs({
-                walkDay: new DogWalkDay(),
-                todayWalkTime: new TodayWalkTime(),
-                name: `test-dog${dogs.length + 1}`,
-                breedId: getRandomInt({ min: 1, max: breedsLength }),
-                gender: GENDER.Male,
-                birth: '2023-06-25',
-                isNeutered: true,
-                weight: 5,
-                profilePhotoUrl: 'default/profile.png',
-                isWalking: false,
-            });
+    constructor(
+        private readonly dataSource: DataSource,
+        private readonly n: number,
+    ) {}
 
-            dogs.push(dog);
-            usersDogs.push(new UsersDogs({ userId: index + 1, dogId: dogs.length }));
+    @Transactional()
+    async createMockUsers(): Promise<ConsoleTableRowFormat[]> {
+        this.users = Array(this.n)
+            .fill(undefined)
+            .map(
+                (_, i) =>
+                    new Users({
+                        nickname: `test-user${i + 1}#${generateUuid()}`,
+                        email: `test-user${i + 1}@mail.com`,
+                        profileImageUrl: 'default/profile.png',
+                        role: ROLE.User,
+                        mainDogId: null,
+                        oauthId: (i + 1).toString(),
+                        oauthAccessToken: OAUTH_ACCESS_TOKEN,
+                        oauthRefreshToken: OAUTH_REFRESH_TOKEN,
+                        refreshToken: VALID_REFRESH_TOKEN_100_YEARS,
+                    }),
+            );
+
+        await this.dataSource.getRepository(Users).save(this.users);
+
+        return [{ Entity: 'Users', Count: this.users.length }];
+    }
+
+    @Transactional()
+    async createMockDogs(): Promise<ConsoleTableRowFormat[]> {
+        const breedData = JSON.parse(fs.readFileSync('resources/breedData.json', 'utf-8'));
+        const breedsLength = breedData.length;
+
+        for (let userId = 1; userId <= this.n; userId++) {
+            const numberOfDogs = getRandomInt({ max: 5 });
+
+            for (let i = 0; i < numberOfDogs; i++) {
+                const dog = new Dogs({
+                    walkDay: new DogWalkDay(),
+                    todayWalkTime: new TodayWalkTime(),
+                    name: `test-dog${this.dogs.length + 1}`,
+                    breedId: getRandomInt({ min: 1, max: breedsLength }),
+                    gender: GENDER.Male,
+                    birth: '2023-06-25',
+                    isNeutered: true,
+                    weight: 5,
+                    profilePhotoUrl: 'default/profile.png',
+                    isWalking: false,
+                });
+
+                this.dogs.push(dog);
+                this.usersDogs.push(new UsersDogs({ userId, dogId: this.dogs.length }));
+            }
         }
-    });
 
-    return [dogs, usersDogs];
+        await this.dataSource.getRepository(Dogs).save(this.dogs);
+        await this.dataSource.getRepository(UsersDogs).save(this.usersDogs);
+
+        return [
+            { Entity: 'Dogs', Count: this.dogs.length },
+            { Entity: 'UserDogs', Count: this.usersDogs.length },
+        ];
+    }
+
+    private async getUsersWithDogs(): Promise<UserWithDogs[]> {
+        return this.dataSource
+            .createQueryBuilder(UsersDogs, 'usersDogs')
+            .select('usersDogs.user_id', 'userId')
+            .addSelect('JSON_ARRAYAGG(usersDogs.dog_id)', 'dogIds')
+            .groupBy('usersDogs.user_id')
+            .getRawMany();
+    }
+
+    @Transactional()
+    async createMockJournals() {
+        const usersWithDogs = await this.getUsersWithDogs();
+
+        let journalId = 0;
+        for (const { userId, dogIds } of usersWithDogs) {
+            const numberOfJournals = getRandomInt({ max: 50 });
+            const photoUrls = [`${userId}/photo1.jpeg`, `${userId}/photo2.png`];
+
+            for (let i = 0; i < numberOfJournals; i++) {
+                journalId++;
+
+                const journal = new Journals({
+                    userId,
+                    routes: '[{"lat": 87.4, "lng" : 85.222}, {"lat": 75.23, "lng" : 104.4839}]',
+                    calories: 500,
+                    memo: 'Enjoyed the walk with Buddy!',
+                    startedAt: getRandomPastDate({ days: 30 }),
+                    duration: 30,
+                    distance: 5,
+                });
+
+                const walkDogIds = getRandomElements(dogIds);
+                const walkPhotos = getRandomElements(photoUrls);
+
+                const journalDogs = walkDogIds.map((dogId) => new JournalsDogs({ dogId, journalId }));
+                const journalPhotos = walkPhotos.map((photoUrl) => new JournalPhotos({ photoUrl, journalId }));
+
+                const excrements: Excrements[] = [];
+                walkDogIds.forEach((dogId) => {
+                    excrements.push(
+                        new Excrements({
+                            journalId,
+                            dogId,
+                            type: getObjectValue(EXCREMENT),
+                            coordinate: `POINT(87.4 85.222)`,
+                        }),
+                    );
+                });
+
+                this.journals.push(journal);
+                this.journalsDogs.push(...journalDogs);
+                this.journalPhotos.push(...journalPhotos);
+                this.excrements.push(...excrements);
+            }
+        }
+
+        await this.dataSource.getRepository(Journals).save(this.journals);
+        await this.dataSource.getRepository(JournalsDogs).save(this.journalsDogs);
+        await this.dataSource.getRepository(JournalPhotos).save(this.journalPhotos);
+        await this.dataSource.getRepository(Excrements).save(this.excrements);
+
+        return [
+            { Entity: 'Journals', Count: this.journals.length },
+            { Entity: 'JournalsDogs', Count: this.journalsDogs.length },
+            { Entity: 'JournalPhotos', Count: this.journalPhotos.length },
+            { Entity: 'Excrements', Count: this.excrements.length },
+        ];
+    }
 }

--- a/backend/test/performance/utils/createMockEntity.util.ts
+++ b/backend/test/performance/utils/createMockEntity.util.ts
@@ -95,25 +95,27 @@ export class CreateMockEntity {
             }
         }
 
-        await this.dataSource.createQueryBuilder(Dogs, 'dogs').insert().values(this.dogs).updateEntity(false).execute();
-        await this.dataSource
-            .createQueryBuilder(UsersDogs, 'usersDogs')
-            .insert()
-            .values(this.usersDogs)
-            .updateEntity(false)
-            .execute();
-        await this.dataSource
-            .createQueryBuilder(DogWalkDay, 'dogWalkDay')
-            .insert()
-            .values(Array(this.n).fill(new DogWalkDay()))
-            .updateEntity(false)
-            .execute();
-        await this.dataSource
-            .createQueryBuilder(TodayWalkTime, 'todayWalkTime')
-            .insert()
-            .values(Array(this.n).fill(new TodayWalkTime()))
-            .updateEntity(false)
-            .execute();
+        await Promise.all([
+            this.dataSource.createQueryBuilder(Dogs, 'dogs').insert().values(this.dogs).updateEntity(false).execute(),
+            this.dataSource
+                .createQueryBuilder(UsersDogs, 'usersDogs')
+                .insert()
+                .values(this.usersDogs)
+                .updateEntity(false)
+                .execute(),
+            this.dataSource
+                .createQueryBuilder(DogWalkDay, 'dogWalkDay')
+                .insert()
+                .values(Array(this.n).fill(new DogWalkDay()))
+                .updateEntity(false)
+                .execute(),
+            this.dataSource
+                .createQueryBuilder(TodayWalkTime, 'todayWalkTime')
+                .insert()
+                .values(Array(this.n).fill(new TodayWalkTime()))
+                .updateEntity(false)
+                .execute(),
+        ]);
 
         return [
             { Entity: 'Dogs', Count: this.dogs.length },
@@ -176,10 +178,12 @@ export class CreateMockEntity {
             }
         }
 
-        await this.dataSource.getRepository(Journals).insert(this.journals);
-        await this.dataSource.getRepository(JournalsDogs).insert(this.journalsDogs);
-        await this.dataSource.getRepository(JournalPhotos).insert(this.journalPhotos);
-        await this.dataSource.getRepository(Excrements).insert(this.excrements);
+        await Promise.all([
+            this.dataSource.getRepository(Journals).insert(this.journals),
+            this.dataSource.getRepository(JournalsDogs).insert(this.journalsDogs),
+            this.dataSource.getRepository(JournalPhotos).insert(this.journalPhotos),
+            this.dataSource.getRepository(Excrements).insert(this.excrements),
+        ]);
 
         return [
             { Entity: 'Journals', Count: this.journals.length },

--- a/backend/test/performance/utils/random.util.ts
+++ b/backend/test/performance/utils/random.util.ts
@@ -119,3 +119,24 @@ export function getRandomElements<T>(
 
     return arrayCopy.slice(min);
 }
+
+export function getRandomElement<T>(array: ReadonlyArray<T>): T {
+    if (array == null) {
+        throw new Error('No array given.');
+    }
+
+    if (array.length === 0) {
+        throw new Error('Cannot get value from empty dataset.');
+    }
+
+    const index = array.length > 1 ? getRandomInt({ max: array.length - 1 }) : 0;
+
+    return array[index];
+}
+
+export function getObjectValue<T extends Record<string, unknown>>(object: T): T[keyof T] {
+    const array: Array<keyof T> = Object.keys(object);
+    const key = getRandomElement(array);
+
+    return object[key];
+}

--- a/backend/test/performance/utils/random.util.ts
+++ b/backend/test/performance/utils/random.util.ts
@@ -61,3 +61,61 @@ export function getRandomPastDate(
 
     return date;
 }
+
+function shuffle<T>(list: T[], options: { inplace?: boolean } = {}): T[] {
+    const { inplace = false } = options;
+
+    if (!inplace) {
+        list = [...list];
+    }
+
+    for (let i = list.length - 1; i > 0; --i) {
+        const j = getRandomInt(i);
+        [list[i], list[j]] = [list[j], list[i]];
+    }
+
+    return list;
+}
+
+export function getRandomElements<T>(
+    array: ReadonlyArray<T>,
+    count?:
+        | number
+        | {
+              min: number; // default 1
+              max: number; // default array.length
+          },
+): T[] {
+    if (array == null) {
+        throw new Error('No array given.');
+    }
+
+    if (array.length === 0) {
+        return [];
+    }
+
+    const numElements = getRandomInt(count ?? { min: 1, max: array.length });
+
+    const arrayCopy = [...array];
+
+    if (numElements >= array.length) {
+        return shuffle(arrayCopy);
+    } else if (numElements <= 0) {
+        return [];
+    }
+
+    let i = array.length;
+    const min = i - numElements;
+    let temp: T;
+    let index: number;
+
+    // Shuffle the last `count` elements of the array
+    while (i-- > min) {
+        index = getRandomInt(i);
+        temp = arrayCopy[index];
+        arrayCopy[index] = arrayCopy[i];
+        arrayCopy[i] = temp;
+    }
+
+    return arrayCopy.slice(min);
+}

--- a/backend/test/test-utils.ts
+++ b/backend/test/test-utils.ts
@@ -107,7 +107,9 @@ interface InsertMockUsersParams {
 
 // mockUsers 생성
 export const insertMockUsers = async ({ mockUsers }: InsertMockUsersParams) => {
-    await dataSource.getRepository(Users).insert(mockUsers);
+    mockUsers = Array.isArray(mockUsers) ? mockUsers : [mockUsers];
+
+    await dataSource.getRepository(Users).save(mockUsers);
 };
 
 export const clearUsers = async () => {


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- n명의 사용자는 random한 강아지들과 함께 0~50개의 산책 일지를 random하게 생성한다.
- 산책 일지는 통계 API를 고려하여 30일 전 ~ 오늘 사이의 날짜로 random하게 설정했다.
- 사용자 100명 data 삽입 테스트를 해본 결과 성능 개선이 잘 된 것을 확인할 수 있다. (순서대로 적용)
  이전 작업 대비 개선된 정도를 확인해보면 `save`에서 `insert`로 바꿨을 때 불필요한 query들이 제거되고 bulk insert가 의도한대로 이루어지면서 큰 성능 개선이 일어난 것을 확인할 수 있다. 실제로 `ENABLE_QUERY_LOGGER=true`로 query log를 보며 확인했다.
  |작업| 100명의 사용자를 생성했을 때 data 당 평균 삽입 시간|
  |--|:--:|
  |독립적인 삽입 method를 병렬로 처리|0.8~1ms|
  |데이터 삽입 시 `save` 대신 `insert` 사용|0.05ms|
  |method 내부 query들을 병렬 처리|0.02~0.03ms|
- 사용자 100명 data 삽입 예시 (삽입에 걸린 시간과 전체 data size를 출력하도록 업데이트함)
  ```bash
  $ MYSQL_DATABASE=performance DATA_SIZE=100 npm run test:response-time
  
  > nest-js-example@0.0.1 test:response-time
  > cross-env NODE_ENV=test ts-node ./test/performance/response-time.ts
  
  Test server running at http://localhost:3333
  Connected database: performance
  Successfully inserted test data (+320ms):
  ┌─────────┬─────────────────┬───────┐
  │ (index) │     Entity      │ Count │
  ├─────────┼─────────────────┼───────┤
  │    0    │     'Users'     │  100  │
  │    1    │     'Dogs'      │  244  │
  │    2    │   'UserDogs'    │  244  │
  │    3    │   'Journals'    │ 1960  │
  │    4    │ 'JournalsDogs'  │ 3982  │
  │    5    │ 'JournalPhotos' │ 2930  │
  │    6    │  'Excrements'   │ 3982  │
  └─────────┴─────────────────┴───────┘
  Total data size: 13442
  Cleared all test data
  ```

## 링크 (Links)
https://www.notion.so/do0ori/API-response-time-script-insertTestData-dd1e50a6f8a44a1a930559ffc0796895

## 기타 사항 (Etc)
~~삽입 시간 개선을 위한 병렬 처리는 아직 작업 중.
실제 삽입 시간을 비교해서 적용할 예정.~~ 완료

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
