### PR TITLE
backend/DANG-1144: response-time script에서 각 기능을 독립적으로 사용할 수 있도록 분리

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -21,6 +21,8 @@
         "test:e2e-watch": "cross-env NODE_ENV=test jest --watch --config ./test/jest-e2e.json --maxWorkers=1",
         "test:only-changed": "cross-env NODE_ENV=test jest --onlyChanged",
         "test:response-time": "cross-env NODE_ENV=test ts-node ./test/performance/response-time.ts",
+        "test:insert": "cross-env NODE_ENV=test ts-node ./test/performance/insert-test-data.ts",
+        "test:clear": "cross-env NODE_ENV=test ts-node ./test/performance/clear-database.ts",
         "prepare": "cd .. && husky backend/.husky"
     },
     "lint-staged": {

--- a/backend/test/performance/clear-database.ts
+++ b/backend/test/performance/clear-database.ts
@@ -1,0 +1,17 @@
+import { TestApp } from './utils/testApp.util';
+
+const clearTestData = async () => {
+    const testApp = new TestApp();
+
+    await testApp.start();
+
+    try {
+        await testApp.clearTestData();
+    } catch (error) {
+        console.error('Error during test data insertion:', error);
+    } finally {
+        await testApp.terminate();
+    }
+};
+
+clearTestData();

--- a/backend/test/performance/insert-test-data.ts
+++ b/backend/test/performance/insert-test-data.ts
@@ -1,0 +1,24 @@
+import { TestApp } from './utils/testApp.util';
+
+const DATA_SIZE = parseInt(process.env.DATA_SIZE!);
+
+const insertTestData = async () => {
+    if (isNaN(DATA_SIZE)) {
+        throw new Error('DATA_SIZE가 정의되지 않았거나 유효한 숫자가 아닙니다. .env.test 파일을 수정해주세요.');
+    }
+
+    const testApp = new TestApp();
+
+    await testApp.start();
+
+    try {
+        await testApp.clearTestData({ keepSeedData: true });
+        await testApp.insertTestData(DATA_SIZE);
+    } catch (error) {
+        console.error('Error during test data insertion:', error);
+    } finally {
+        await testApp.terminate();
+    }
+};
+
+insertTestData();

--- a/backend/test/performance/response-time.ts
+++ b/backend/test/performance/response-time.ts
@@ -51,12 +51,10 @@ const runResponseTimeTest = async () => {
     await testApp.start();
 
     try {
-        await testApp.insertTestData(DATA_SIZE);
         await runPostmanCollectionWithNewman(COLLECTION_ID, REQUEST_OR_FOLDER_ID, ITERATION_COUNT);
     } catch (error) {
         console.error('Error during test execution:', error);
     } finally {
-        await testApp.clearTestData();
         await testApp.terminate();
     }
 };

--- a/backend/test/performance/utils/createMockEntity.util.ts
+++ b/backend/test/performance/utils/createMockEntity.util.ts
@@ -132,7 +132,7 @@ export class CreateMockEntity {
             .getRawMany();
     }
 
-    async createMockJournals() {
+    async createMockJournals(): Promise<ConsoleTableRowFormat[]> {
         const usersWithDogs = await this.getUsersWithDogs();
 
         let journalId = 0;

--- a/backend/test/performance/utils/testApp.util.ts
+++ b/backend/test/performance/utils/testApp.util.ts
@@ -1,0 +1,112 @@
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getDataSourceToken } from '@nestjs/typeorm';
+import * as cookieParser from 'cookie-parser';
+import { DataSource, EntityMetadata } from 'typeorm';
+import { initializeTransactionalContext } from 'typeorm-transactional';
+
+import { CreateMockEntity } from './createMockEntity.util';
+
+import { AppModule } from '../../../src/app.module';
+import { GoogleService } from '../../../src/auth/oauth/google.service';
+import { KakaoService } from '../../../src/auth/oauth/kakao.service';
+import { NaverService } from '../../../src/auth/oauth/naver.service';
+import { S3Service } from '../../../src/s3/s3.service';
+import { color } from '../../../src/utils/ansi.util';
+import { MockOauthService } from '../__mocks__/oauth.service';
+import { MockS3Service } from '../__mocks__/s3.service';
+
+export class TestApp {
+    app: INestApplication;
+    dataSource: DataSource;
+
+    async start(): Promise<void> {
+        initializeTransactionalContext();
+
+        const moduleFixture: TestingModule = await Test.createTestingModule({
+            imports: [AppModule],
+        })
+            .overrideProvider(GoogleService)
+            .useValue(MockOauthService)
+            .overrideProvider(KakaoService)
+            .useValue(MockOauthService)
+            .overrideProvider(NaverService)
+            .useValue(MockOauthService)
+            .overrideProvider(S3Service)
+            .useValue(MockS3Service)
+            .compile();
+
+        this.app = moduleFixture.createNestApplication();
+
+        this.app.use(cookieParser());
+
+        await (async () => {
+            await this.app.listen(process.env.PORT!, () => {
+                console.log(`Test server running at http://${process.env.MYSQL_HOST}:${process.env.PORT}`);
+            });
+        })();
+
+        this.dataSource = this.app.get(getDataSourceToken());
+
+        console.log(`Connected database:`, color(process.env.MYSQL_DATABASE!, 'Yellow'));
+    }
+
+    async terminate(): Promise<void> {
+        console.log('Close connection with the database');
+        await this.dataSource.destroy();
+
+        console.log('Terminate the test application');
+        await this.app.close();
+    }
+
+    async insertTestData(n: number): Promise<void> {
+        await this.dataSource.query('SET GLOBAL FOREIGN_KEY_CHECKS = 0;');
+
+        const mockEntityCreator = new CreateMockEntity(this.dataSource, n);
+
+        const startTime = Date.now();
+
+        const [userResults, dogResults] = await Promise.all([
+            mockEntityCreator.createMockUsers(),
+            mockEntityCreator.createMockDogs(),
+        ]);
+        const journalResults = await mockEntityCreator.createMockJournals();
+
+        const endTime = Date.now();
+        const duration = endTime - startTime;
+
+        console.log(`Successfully inserted test data (${color(`+${duration}ms`, 'Cyan')}):`);
+
+        await this.dataSource.query('SET GLOBAL FOREIGN_KEY_CHECKS = 1;');
+
+        const table = [...userResults, ...dogResults, ...journalResults];
+        const totalSize = table.reduce((count, entity) => count + entity.Count, 0);
+
+        console.table(table);
+        console.log('Total data size:', totalSize);
+    }
+
+    async clearTestData(
+        options: {
+            keepSeedData?: boolean; // default false
+        } = {},
+    ): Promise<void> {
+        const { keepSeedData = false } = options;
+
+        const entityMetadatas: EntityMetadata[] = keepSeedData
+            ? this.dataSource.entityMetadatas.filter(
+                  (entityMetadata: EntityMetadata) => entityMetadata.name !== 'Breed',
+              )
+            : this.dataSource.entityMetadatas;
+
+        await this.dataSource.query('SET FOREIGN_KEY_CHECKS = 0;');
+
+        for (const entityMetadata of entityMetadatas) {
+            await this.dataSource.getRepository(entityMetadata.name).clear();
+        }
+
+        await this.dataSource.query('SET FOREIGN_KEY_CHECKS = 1;');
+
+        console.log('Cleared all test data');
+    }
+}


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- TestApp 시작, 종료, TestData 삽입, 삭제 기능을 class로 분리하여 정의했다.
- 원하는 크기의 test data를 DB에 손쉽게 삽입, 삭제할 수 있는 script 파일을 작성했다.
- package.json 파일의 scripts에 명령어를 추가해 쉽게 사용할 수 있다. 다음은 사용 예시이다.
  ```bash
  $ MYSQL_DATABASE=performance DATA_SIZE=100 npm run test:insert
  
  > nest-js-example@0.0.1 test:insert
  > cross-env NODE_ENV=test ts-node ./test/performance/insert-test-data.ts
  
  Test server running at http://localhost:3333
  Connected database: performance
  Cleared all test data
  Successfully inserted test data (+379ms):
  ┌─────────┬─────────────────┬───────┐
  │ (index) │     Entity      │ Count │
  ├─────────┼─────────────────┼───────┤
  │    0    │     'Users'     │  100  │
  │    1    │     'Dogs'      │  227  │
  │    2    │   'UserDogs'    │  227  │
  │    3    │   'Journals'    │ 2089  │
  │    4    │ 'JournalsDogs'  │ 4023  │
  │    5    │ 'JournalPhotos' │ 3164  │
  │    6    │  'Excrements'   │ 4023  │
  └─────────┴─────────────────┴───────┘
  Total data size: 13853
  Close connection with the database
  Terminate the test application
  ```
  ```bash
  $ MYSQL_DATABASE=performance npm run test:clear
  
  > nest-js-example@0.0.1 test:clear
  > cross-env NODE_ENV=test ts-node ./test/performance/clear-database.ts
  
  Test server running at http://localhost:3333
  Connected database: performance
  Cleared all test data
  Close connection with the database
  Terminate the test application
  ```
- response-time script는 test data로 test 시에는 Oauth와 S3를 mock해야 하기 때문에 필요하다.

## 링크 (Links)
https://www.notion.so/do0ori/response-time-script-ffab33a08a454fe489fd05b35384a5c1

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
