### PR TITLE
backend/DANG-1049: 이미지 파일 확장자만 받도록 custom validation pipe 추가

### DIFF
--- a/backend/src/s3/pipes/file-type-validation.pipe.ts
+++ b/backend/src/s3/pipes/file-type-validation.pipe.ts
@@ -25,15 +25,17 @@ const allowedFileTypes = [
 export type FileType = (typeof allowedFileTypes)[number];
 
 @Injectable()
-export class FileTypeValidationPipe implements PipeTransform {
+export class FileTypeValidationPipe implements PipeTransform<any, FileType[]> {
     readonly allowedExtensions = allowedFileTypes;
 
-    transform(value: any) {
+    transform(value: any): FileType[] {
         if (!isTypedArray(value, 'string')) {
             throw new BadRequestException('Validation failed (string array expected)');
         }
 
-        const invalidFiles = value.filter((type: any) => !this.allowedExtensions.includes(type.toLowerCase()));
+        const invalidFiles = value.filter(
+            (type: string) => !this.allowedExtensions.includes(type.toLowerCase() as FileType),
+        );
 
         if (invalidFiles.length > 0) {
             throw new BadRequestException(
@@ -41,6 +43,6 @@ export class FileTypeValidationPipe implements PipeTransform {
             );
         }
 
-        return value;
+        return value as FileType[];
     }
 }

--- a/backend/src/s3/pipes/file-type-validation.pipe.ts
+++ b/backend/src/s3/pipes/file-type-validation.pipe.ts
@@ -1,0 +1,46 @@
+import { BadRequestException, Injectable, PipeTransform } from '@nestjs/common';
+
+import { isTypedArray } from '../../utils/validator.util';
+
+const allowedFileTypes = [
+    'xbm',
+    'tif',
+    'jfif',
+    'ico',
+    'tiff',
+    'gif',
+    'svg',
+    'webp',
+    'svgz',
+    'jpg',
+    'jpeg',
+    'png',
+    'bmp',
+    'pjp',
+    'apng',
+    'pjpeg',
+    'avif',
+] as const;
+
+export type FileType = (typeof allowedFileTypes)[number];
+
+@Injectable()
+export class FileTypeValidationPipe implements PipeTransform {
+    readonly allowedExtensions = allowedFileTypes;
+
+    transform(value: any) {
+        if (!isTypedArray(value, 'string')) {
+            throw new BadRequestException('Validation failed (string array expected)');
+        }
+
+        const invalidFiles = value.filter((type: any) => !this.allowedExtensions.includes(type.toLowerCase()));
+
+        if (invalidFiles.length > 0) {
+            throw new BadRequestException(
+                `Invalid file types: ${invalidFiles.join(', ')}. Allowed types are: ${this.allowedExtensions.join(', ')}`,
+            );
+        }
+
+        return value;
+    }
+}

--- a/backend/src/s3/s3.controller.ts
+++ b/backend/src/s3/s3.controller.ts
@@ -1,5 +1,6 @@
 import { Body, Controller, Delete, HttpCode, ParseArrayPipe, Post } from '@nestjs/common';
 
+import { FileType, FileTypeValidationPipe } from './pipes/file-type-validation.pipe';
 import { S3Service } from './s3.service';
 
 import { PresignedUrlInfo } from './types/presigned-url-info.type';
@@ -15,7 +16,7 @@ export class S3Controller {
     @HttpCode(200)
     async presignedUrl(
         @User() user: AccessTokenPayload,
-        @Body(new ParseArrayPipe({ items: String, separator: ',' })) type: string[],
+        @Body(new FileTypeValidationPipe()) type: FileType[],
     ): Promise<PresignedUrlInfo[]> {
         return await this.s3Service.createPresignedUrlWithClientForPut(user.userId, type);
     }

--- a/backend/src/s3/s3.service.ts
+++ b/backend/src/s3/s3.service.ts
@@ -3,6 +3,7 @@ import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { ForbiddenException, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 
+import { FileType } from './pipes/file-type-validation.pipe';
 import { PresignedUrlInfo } from './types/presigned-url-info.type';
 
 import { WinstonLoggerService } from '../common/logger/winstonLogger.service';
@@ -20,13 +21,13 @@ export class S3Service {
         this.s3Client = new S3Client({ region: this.configService.getOrThrow('AWS_S3_REGION') });
     }
 
-    private makeFileName(userId: number, type: string[]): string[] {
+    private makeFileName(userId: number, type: FileType[]): string[] {
         return type.map((curType) => `${userId}/${generateUuid()}.${curType}`);
     }
 
-    async createPresignedUrlWithClientForPut(userId: number, type: string[]): Promise<PresignedUrlInfo[]> {
+    async createPresignedUrlWithClientForPut(userId: number, type: FileType[]): Promise<PresignedUrlInfo[]> {
         const filenameArray = this.makeFileName(userId, type);
-        const presignedUrlInfoPromises = await filenameArray.map(async (curFileName) => {
+        const presignedUrlInfoPromises = filenameArray.map(async (curFileName) => {
             const command = new PutObjectCommand({
                 Bucket: BUCKET_NAME,
                 ContentType: `image/${type}`,

--- a/backend/src/statistics/pipes/period-validation.pipe.ts
+++ b/backend/src/statistics/pipes/period-validation.pipe.ts
@@ -3,24 +3,24 @@ import { BadRequestException, Injectable, PipeTransform } from '@nestjs/common';
 export type Period = 'month' | 'week';
 
 @Injectable()
-export class PeriodValidationPipe implements PipeTransform<Period, Period> {
+export class PeriodValidationPipe implements PipeTransform<string, Period> {
     private readonly allowedPeriods;
 
     constructor(allowedPeriods: Period[]) {
         this.allowedPeriods = allowedPeriods;
     }
 
-    transform(value: Period): Period {
+    transform(value: string): Period {
         if (!value) {
             throw new BadRequestException('period query parameter is missing.');
         }
 
-        if (!this.allowedPeriods.includes(value)) {
+        if (!this.allowedPeriods.includes(value as Period)) {
             throw new BadRequestException(
                 `Invalid period: ${value}. Allowed periods are: ${this.allowedPeriods.join(', ')}`,
             );
         }
 
-        return value;
+        return value as Period;
     }
 }

--- a/backend/test/s3.e2e-spec.ts
+++ b/backend/test/s3.e2e-spec.ts
@@ -65,6 +65,32 @@ describe('S3Controller (e2e)', () => {
             });
         });
 
+        context('사용자가 유효하지 않은 body로 presignedUrl 요청을 보내면', () => {
+            it('400 상태 코드를 반환해야 한다.', () => {
+                return request(app.getHttpServer())
+                    .post('/images/presigned-url')
+                    .set('Authorization', `Bearer ${VALID_ACCESS_TOKEN_100_YEARS}`)
+                    .send(['jpeg', 'avi'])
+                    .expect(400);
+            });
+
+            it('400 상태 코드를 반환해야 한다.', () => {
+                return request(app.getHttpServer())
+                    .post('/images/presigned-url')
+                    .set('Authorization', `Bearer ${VALID_ACCESS_TOKEN_100_YEARS}`)
+                    .send([1, 'gif'])
+                    .expect(400);
+            });
+
+            it('400 상태 코드를 반환해야 한다.', () => {
+                return request(app.getHttpServer())
+                    .post('/images/presigned-url')
+                    .set('Authorization', `Bearer ${VALID_ACCESS_TOKEN_100_YEARS}`)
+                    .send('png')
+                    .expect(400);
+            });
+        });
+
         testUnauthorizedAccess('이미지 업로드를 위한 presignedUrl', 'post', '/images/presigned-url');
     });
 


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- `<input type="file" accept="image/*" />`를 사용할 때 허용되는 이미지 파일 확장자 목록을 참고해 이미지 파일 확장자만 받도록 custom validation pipe를 추가했다.
  ![image](https://github.com/dangdangwalk/dangdang-walk/assets/71831926/22f4eb12-5c52-440e-aa20-9acf4f2f5099)
- s3 e2e test 파일에 `FileTypeValidationPipe` 관련 test case 추가

## 링크 (Links)
https://www.notion.so/do0ori/custom-validation-pipe-43a5d9ccd8f74e7e823c8cfb2b87c2f7

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
