### PR TITLE
backend/DANG-1152: 산책 중인 강아지의 경우 삭제하지 못하도록 예외처리 추가

### DIFF
--- a/docs/dogs/id.yaml
+++ b/docs/dogs/id.yaml
@@ -133,3 +133,5 @@ delete:
       description: 회원이 소유한 강아지가 아닌 경우
     "404":
       description: 회원 또는 강아지를 찾을 수 없는 경우
+    "409":
+      description: 강아지의 상태가 산책 중(is_walking === true)인 경우 


### PR DESCRIPTION
## 작업 내용 (Content)
산책 중인 강아지는 삭제하지 못하도록 예외처리를 추가했습니다. 
서버 리소스의 상태와 일치하지 않는 요청이 온 경우인 409 conflict 에러를 던지도록 처리했습니다. 

## 링크 (Links)
https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
