### PR TITLE
frontend/DANG-1154: 산책일지 상세 페이지에서 loader를 커스텀 hook으로 대체

### DIFF
--- a/frontend/src/hooks/useJournal.ts
+++ b/frontend/src/hooks/useJournal.ts
@@ -1,0 +1,21 @@
+import { JournalDetail, fetchJournal } from '@/api/journal';
+import { useEffect, useState } from 'react';
+
+const useJournal = (journalId: number) => {
+    const [journal, setJournal] = useState<JournalDetail>({
+        journalInfo: { id: 0, routes: [], memo: '', photoUrls: [] },
+        dogs: [],
+    });
+
+    useEffect(() => {
+        const asyncFunction = async () => {
+            const fetchedJournal = await fetchJournal(journalId);
+            setJournal(fetchedJournal);
+        };
+        asyncFunction();
+    }, []);
+
+    return journal;
+};
+
+export default useJournal;

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,12 +1,13 @@
-import { fetchJournal } from '@/api/journal';
 import queryClient from '@/api/queryClient';
+import AuthLayout from '@/components/AuthLayout';
 import Health from '@/pages/Health';
 import Home from '@/pages/Home';
+import Journals from '@/pages/Journals';
 import JournalCreateForm from '@/pages/Journals/CreateForm';
 import Detail from '@/pages/Journals/Detail';
-import Journals from '@/pages/Journals';
-import OauthCallback from '@/pages/OauthCallback';
 import MyPage from '@/pages/MyPage';
+import OauthCallback from '@/pages/OauthCallback';
+import SignUp from '@/pages/SignUp';
 import Walk from '@/pages/Walk';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
@@ -15,8 +16,6 @@ import { RouterProvider, createBrowserRouter } from 'react-router-dom';
 import App from './App';
 import './index.css';
 import reportWebVitals from './reportWebVitals';
-import SignUp from '@/pages/SignUp';
-import AuthLayout from '@/components/AuthLayout';
 const router = createBrowserRouter([
     {
         path: '/',
@@ -70,10 +69,6 @@ const router = createBrowserRouter([
             {
                 path: '/journals/:journalId',
                 element: <Detail />,
-                loader: async ({ params }) => {
-                    const journalId = Number(params.journalId);
-                    return await fetchJournal(journalId);
-                },
             },
         ],
     },

--- a/frontend/src/pages/Journals/Detail.tsx
+++ b/frontend/src/pages/Journals/Detail.tsx
@@ -1,4 +1,4 @@
-import { JournalDetail, remove as removeJournal, update as updateJournal } from '@/api/journal';
+import { remove as removeJournal, update as updateJournal } from '@/api/journal';
 import { deleteImages, getUploadUrl, uploadImage } from '@/api/upload';
 import { ReactComponent as Arrow } from '@/assets/icons/ic-arrow-right.svg';
 import { ReactComponent as Meatball } from '@/assets/icons/ic-meatball.svg';
@@ -22,14 +22,16 @@ import Navbar from '@/components/journals/Navbar';
 import PhotoSection from '@/components/journals/PhotoSection';
 import Map from '@/components/walk/Map';
 import WalkInfo from '@/components/walk/WalkInfo';
+import useJournal from '@/hooks/useJournal';
 import useToast from '@/hooks/useToast';
 import { useStore } from '@/store';
 import { getFileName } from '@/utils/url';
 import { FormEvent, useEffect, useRef, useState } from 'react';
-import { useLoaderData, useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 
 export default function Detail() {
-    const journalDetail = useLoaderData() as JournalDetail;
+    const params = useParams();
+    const journalDetail = useJournal(Number(params.journalId));
     const { journalInfo, dogs: dogsFromAPI, excrements = [] } = journalDetail;
     const { id: journalId, routes, memo, photoUrls: photoFileNames } = journalInfo;
 
@@ -82,7 +84,7 @@ export default function Detail() {
     useEffect(() => {
         if (textAreaRef.current === null) return;
         textAreaRef.current.value = memo;
-    }, []);
+    }, [journalDetail]);
 
     return (
         <>


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->

## 링크 (Links)

## 기타 사항 (Etc)
https://www.notion.so/do0ori/loader-hook-5c1f6a1099d043d8a247a523ffacb0c7?pvs=4

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
