### PR TITLE
backend/DANG-1059: journals 쿼리에 select 옵션 추가

### DIFF
--- a/backend/src/journals/types/create-journal-data.type.ts
+++ b/backend/src/journals/types/create-journal-data.type.ts
@@ -1,4 +1,5 @@
 import { Location, journalLocation } from '../dtos/create-journal.dto';
+import { Journals } from '../journals.entity';
 
 export interface CreateExcrementsInfo {
     dogId: number;
@@ -15,11 +16,8 @@ export class CreateJournalInfo {
     memo: string;
     photoUrls: string[];
 
-    static getKeysForJournalTable() {
+    static getKeysForJournalTable(): Array<keyof Journals> {
         return ['distance', 'calories', 'startedAt', 'duration', 'routes', 'memo'];
-    }
-    static getKeysForJournalPhotoTable() {
-        return ['photoUrls'];
     }
 }
 

--- a/backend/src/journals/types/journal-detail.type.ts
+++ b/backend/src/journals/types/journal-detail.type.ts
@@ -1,5 +1,9 @@
 import { IsNotEmpty, IsNumber, IsOptional, IsString } from 'class-validator';
 
+import { Dogs } from 'src/dogs/dogs.entity';
+
+import { Journals } from '../journals.entity';
+
 export class PhotoUrlType {
     @IsNotEmpty()
     @IsString()
@@ -22,7 +26,7 @@ export class DogInfoForDetail {
     profilePhotoUrl: string | null;
 
     // TODO: reflect-metadata 사용하도록 변경
-    static getKeysForDogTable() {
+    static getKeysForDogTable(): Array<keyof Dogs> {
         return ['id', 'name', 'profilePhotoUrl'];
     }
 }
@@ -52,11 +56,8 @@ export class JournalInfoForDetail {
     @IsString({ each: true })
     photoUrls: string[];
 
-    static getKeysForJournalTable() {
+    static getKeysForJournalTable(): Array<keyof Journals> {
         return ['routes', 'memo'];
-    }
-    static getKeysForJournalPhotoTable() {
-        return ['photoUrls'];
     }
 }
 

--- a/backend/src/journals/types/journal-info.type.ts
+++ b/backend/src/journals/types/journal-info.type.ts
@@ -1,5 +1,7 @@
 import { IsDate, IsInt, IsNumber } from 'class-validator';
 
+import { Journals } from '../journals.entity';
+
 export class JournalInfoForList {
     @IsNumber()
     journalId: number;
@@ -23,7 +25,7 @@ export class JournalInfoForList {
         return ['journalId', 'startedAt', 'distance', 'calories', 'duration'];
     }
 
-    static getKeysForJournalTable() {
+    static getKeysForJournalTable(): Array<keyof Journals> {
         return ['id', 'startedAt', 'distance', 'calories', 'duration'];
     }
 }

--- a/backend/src/walk/test.walk.service.ts
+++ b/backend/src/walk/test.walk.service.ts
@@ -11,7 +11,7 @@ export class TestWalkService extends WalkService {
         super(usersService, dogsService);
     }
 
-    async checkAvailableDogs(dogIds: number[]) {
+    async checkAvailableDogs(_dogIds: number[]) {
         return Promise.resolve();
     }
 }


### PR DESCRIPTION
## 작업 내용 (Content)
필요한 열만 가져오도록 select 옵션을 추가해 쿼리 성능을 향상하였습니다.

## 링크 (Links)
#### 성능 개선된 케이스
https://www.notion.so/do0ori/5a63faefd23b4bfb8dbd4f06338bcded?p=49ffaf998cb54f578a58487431a1c3a0&pm=s
https://www.notion.so/do0ori/5a63faefd23b4bfb8dbd4f06338bcded?p=968adc4fa24e4a60aa53d4698daa4171&pm=s

#### 이슈 
journals_dogs 테이블에서 journal_id만 select하도록 옵션을 주었지만 실제 실행된 쿼리는 여전히 journal_id, dog_id를 모두 가져오는 문제가 있었습니다.
직접 journal_id만 가져오도록 쿼리를 바꿔서 `EXPLAIN ANALYZE` 해봤더니 cost에 변화는 없었습니다.
이대로 써도 성능에 큰 영향은 없을 것 같지만 찝찝해서 해결책을 찾는 중입니다.
https://www.notion.so/do0ori/946c5f068b79446b85ba2ab5a040822a?v=7bd0ed1cabc7490f83c6c0c4e563bb83&p=83167d9cbd4f4425985a49e0695a7390&pm=s


## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
