### PR TITLE
backend/DANG-1155: AuthService의 비동기 처리 성능 개선

### DIFF
--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -132,11 +132,8 @@ export class AuthService {
 
     @Transactional()
     private async deleteUserData(userId: number) {
-        const dogIds = await this.usersService.getOwnDogsList(userId);
-
-        await Promise.all(dogIds.map((dogId) => this.dogsService.deleteDogFromUser(userId, dogId)));
-
-        await Promise.all([this.usersService.delete({ id: userId }), this.s3Service.deleteObjectFolder(userId)]);
+        await this.dogsService.deleteOwnDogs(userId);
+        await this.usersService.delete(userId);
     }
 
     async validateAccessToken(token: string): Promise<AccessTokenPayload> {

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -97,21 +97,15 @@ export class AuthService {
     async reissueTokens({ oauthId, provider }: RefreshTokenPayload): Promise<AuthData> {
         const { id: userId, oauthRefreshToken } = await this.usersService.findOne({ where: { oauthId } });
 
-        // TODO: Promise.all로 병렬처리 한 후 성능 비교하기
-        // const [
-        //     { access_token: newOauthAccessToken, refresh_token: newOauthRefreshToken },
-        //     newAccessToken,
-        //     newRefreshToken,
-        // ] = await Promise.all([
-        //     this[`${provider}Service`].requestTokenRefresh(oauthRefreshToken),
-        //     this.tokenService.signAccessToken(userId, provider),
-        //     this.tokenService.signRefreshToken(oauthId, provider),
-        // ]);
-        const { access_token: newOauthAccessToken, refresh_token: newOauthRefreshToken } =
-            await this[`${provider}Service`].requestTokenRefresh(oauthRefreshToken);
-
-        const newAccessToken = await this.tokenService.signAccessToken(userId, provider);
-        const newRefreshToken = await this.tokenService.signRefreshToken(oauthId, provider);
+        const [
+            { access_token: newOauthAccessToken, refresh_token: newOauthRefreshToken },
+            newAccessToken,
+            newRefreshToken,
+        ] = await Promise.all([
+            this[`${provider}Service`].requestTokenRefresh(oauthRefreshToken),
+            this.tokenService.signAccessToken(userId, provider),
+            this.tokenService.signRefreshToken(oauthId, provider),
+        ]);
 
         const attributes: Partial<Users> = { oauthAccessToken: newOauthAccessToken, refreshToken: newRefreshToken };
 
@@ -140,14 +134,9 @@ export class AuthService {
     private async deleteUserData(userId: number) {
         const dogIds = await this.usersService.getOwnDogsList(userId);
 
-        // TODO: for문 없애고 batch delete 하기
-        for (const dogId of dogIds) {
-            await this.dogsService.deleteDogFromUser(userId, dogId);
-        }
+        await Promise.all(dogIds.map((dogId) => this.dogsService.deleteDogFromUser(userId, dogId)));
 
-        // TODO: Promise.all로 병렬 처리
-        await this.usersService.delete({ id: userId });
-        await this.s3Service.deleteObjectFolder(userId);
+        await Promise.all([this.usersService.delete({ id: userId }), this.s3Service.deleteObjectFolder(userId)]);
     }
 
     async validateAccessToken(token: string): Promise<AccessTokenPayload> {

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -35,8 +35,8 @@ export class UsersService {
         return this.usersRepository.updateAndFindOne(where, partialEntity);
     }
 
-    async delete(where: FindOptionsWhere<Users>) {
-        return this.usersRepository.delete(where);
+    async delete(userId: number) {
+        await Promise.all([this.usersRepository.delete({ id: userId }), this.s3Service.deleteObjectFolder(userId)]);
     }
 
     async createIfNotExists({ oauthNickname, ...otherAttributes }: CreateUser) {


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- 병렬 처리
  - AuthService의 토큰 재발급 과정에서 Promise.all을 사용하여 병렬적으로 비동기 작업을 처리함.
  - deleteUserData 메서드에서 사용자의 모든 개를 병렬적으로 삭제하도록 수정하고, 사용자 데이터 삭제와 S3 폴더 삭제를 병렬적으로 처리하도록 개선함.
  - DogsService의 deleteDogFromUser 메서드에서 개와 관련된 데이터를 병렬적으로 삭제하도록 수정함.
- bulk delete 처리
  - 사용자가 소유한 강아지를 loop를 돌며 하나씩 삭제하기보다는 deleteOwnDogs라는 method를 추가해 bulk delete하도록 변경
  - usersService.delete가 사용자 삭제 및 사용자의 S3 폴더 삭제까지 병렬로 처리하도록 변경

## 링크 (Links)
https://www.notion.so/do0ori/AuthService-TODO-f58fd84a72a24c5cb2f4cba608838b92

## 기타 사항 (Etc)
https://www.notion.so/do0ori/9d751850cd8e412f907bcc35f8a57c80

사용자가 소유한 강아지 수: $n$
개선 비율: 0 ~ 57%
|  | Query 개수 | $n = 5$일 때<br>API 실행 시간 |
| -- | -- |-- |
|기존 API | $4n + 5$ | 37ms |
|개선된 API | 8 | 16ms |

<!-- notionvc: 66d6af71-d9d1-451a-918e-723ca79cbc0a --><!--EndFragment-->
</body>
</html>

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?