### PR TITLE
backend/DANG-1156: S3Service에서 default 폴더에 존재하는 파일은 삭제되지 않도록 처리

### DIFF
--- a/backend/src/dogs/dogs.spec.ts
+++ b/backend/src/dogs/dogs.spec.ts
@@ -18,7 +18,7 @@ describe('Dogs', () => {
             birth: null,
             isNeutered: true,
             weight: 2,
-            profilePhotoUrl: 'mock_profile_photo.jpg',
+            profilePhotoUrl: 'default/profile.png',
             isWalking: false,
             updatedAt: expect.any(Date),
         });

--- a/backend/src/fixtures/dogs.fixture.ts
+++ b/backend/src/fixtures/dogs.fixture.ts
@@ -13,7 +13,7 @@ export const mockDog = new Dogs({
     birth: null,
     isNeutered: true,
     weight: 2,
-    profilePhotoUrl: 'mock_profile_photo.jpg',
+    profilePhotoUrl: 'default/profile.png',
     isWalking: false,
     updatedAt: new Date('2019-01-01'),
 });
@@ -26,7 +26,7 @@ export const mockDogProfile = {
     isNeutered: true,
     birth: null,
     weight: 2,
-    profilePhotoUrl: 'mock_profile_photo.jpg',
+    profilePhotoUrl: 'default/profile.png',
 };
 
 export const mockDog2 = new Dogs({
@@ -39,7 +39,7 @@ export const mockDog2 = new Dogs({
     birth: null,
     isNeutered: false,
     weight: 1,
-    profilePhotoUrl: 'mock_profile_photo2.jpg',
+    profilePhotoUrl: 'default/profile.png',
     isWalking: false,
     updatedAt: new Date('2019-01-01'),
 });
@@ -52,5 +52,5 @@ export const mockDog2Profile = {
     isNeutered: false,
     birth: null,
     weight: 1,
-    profilePhotoUrl: 'mock_profile_photo2.jpg',
+    profilePhotoUrl: 'default/profile.png',
 };

--- a/backend/src/s3/__mocks__/s3.service.ts
+++ b/backend/src/s3/__mocks__/s3.service.ts
@@ -14,6 +14,8 @@ export const MockS3Service = {
 
     deleteObjects: jest.fn((userId: number, filenames: string[]) => {
         for (const curFilename of filenames) {
+            if (curFilename.startsWith('default/')) return true;
+
             if (parseInt(curFilename.split('/')[0]) !== userId) {
                 throw new ForbiddenException(`User ${userId} is not owner of the file ${curFilename}`);
             }

--- a/backend/src/s3/s3.service.ts
+++ b/backend/src/s3/s3.service.ts
@@ -48,12 +48,19 @@ export class S3Service {
     }
 
     async deleteObjects(userId: number, filenames: string[]) {
-        const objectArray = filenames.map((curFilename) => {
+        const objectArray: {
+            Key: string;
+        }[] = [];
+
+        for (const curFilename of filenames) {
+            if (curFilename.startsWith('default/')) continue;
+
             if (!this.checkUserIdInFilename(userId, curFilename)) {
                 throw new ForbiddenException(`유저 ${userId}은 ${curFilename}에 대한 접근 권한이 없습니다`);
             }
-            return { Key: curFilename };
-        });
+
+            objectArray.push({ Key: curFilename });
+        }
 
         const input = {
             Bucket: BUCKET_NAME,
@@ -72,6 +79,8 @@ export class S3Service {
     }
 
     async deleteSingleObject(userId: number, filename: string) {
+        if (filename.startsWith('default/')) return;
+
         if (!this.checkUserIdInFilename(userId, filename)) {
             throw new ForbiddenException(`유저 ${userId}은/는 ${filename}에 대한 접근 권한이 없습니다`);
         }

--- a/backend/test/auth.e2e-spec.ts
+++ b/backend/test/auth.e2e-spec.ts
@@ -14,8 +14,20 @@ import {
     VALID_REFRESH_TOKEN_100_YEARS,
 } from './constants';
 
-import { clearUsers, closeTestApp, insertMockUsers, setupTestApp, testUnauthorizedAccess } from './test-utils';
+import {
+    clearDogs,
+    clearUsers,
+    closeTestApp,
+    insertMockDogs,
+    insertMockUsers,
+    setupTestApp,
+    testUnauthorizedAccess,
+} from './test-utils';
 
+import { DogWalkDay } from '../src/dog-walk-day/dog-walk-day.entity';
+import { Dogs } from '../src/dogs/dogs.entity';
+import { GENDER } from '../src/dogs/types/gender.type';
+import { TodayWalkTime } from '../src/today-walk-time/today-walk-time.entity';
 import { ROLE } from '../src/users/types/role.type';
 import { Users } from '../src/users/users.entity';
 
@@ -360,9 +372,43 @@ describe('AuthController (e2e)', () => {
                         createdAt: new Date('2019-01-01'),
                     }),
                 });
+                await insertMockDogs({
+                    mockDogs: [
+                        new Dogs({
+                            id: 1,
+                            walkDay: new DogWalkDay(),
+                            todayWalkTime: new TodayWalkTime(),
+                            name: '덕지',
+                            breedId: 1,
+                            gender: GENDER.Male,
+                            birth: null,
+                            isNeutered: true,
+                            weight: 2,
+                            profilePhotoUrl: '1/mock_profile_photo.jpg',
+                            isWalking: false,
+                            updatedAt: new Date('2019-01-01'),
+                        }),
+                        new Dogs({
+                            id: 2,
+                            walkDay: new DogWalkDay(),
+                            todayWalkTime: new TodayWalkTime(),
+                            name: '루이',
+                            breedId: 2,
+                            gender: GENDER.Female,
+                            birth: null,
+                            isNeutered: false,
+                            weight: 1,
+                            profilePhotoUrl: 'default/profile.png',
+                            isWalking: false,
+                            updatedAt: new Date('2019-01-01'),
+                        }),
+                    ],
+                    userId: 1,
+                });
             });
 
             afterEach(async () => {
+                await clearDogs();
                 await clearUsers();
             });
 
@@ -374,6 +420,7 @@ describe('AuthController (e2e)', () => {
                     .expect('set-cookie', /refreshToken=;/);
 
                 expect(await dataSource.getRepository(Users).findOne({ where: { id: 1 } })).toBe(null);
+                expect(await dataSource.getRepository(Dogs).count()).toBe(0);
             });
         });
 

--- a/backend/test/performance/__mocks__/s3.service.ts
+++ b/backend/test/performance/__mocks__/s3.service.ts
@@ -14,6 +14,8 @@ export const MockS3Service = {
 
     deleteObjects: (userId: number, filenames: string[]) => {
         for (const curFilename of filenames) {
+            if (curFilename.startsWith('default/')) return true;
+
             if (parseInt(curFilename.split('/')[0]) !== userId) {
                 throw new ForbiddenException(`User ${userId} is not owner of the file ${curFilename}`);
             }


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- 회원탈퇴 시 사용자가 소유한 강아지도 올바르게 삭제되는지 확인하도록 test case 수정
- S3에서 default 폴더의 파일은 삭제되지 않도록 처리

## 링크 (Links)
https://www.notion.so/do0ori/S3Service-default-c3f131071933419a84d9163d94482d2e

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
