### PR TITLE
backend/DANG-1050: excrements가 없어도 0을 보내도록 변경

### DIFF
--- a/backend/src/journals/journals.service.ts
+++ b/backend/src/journals/journals.service.ts
@@ -90,13 +90,9 @@ export class JournalsService {
         //TODO: GROUP_BY type을 사용해 한번에 가져오게 바꾸기
         const fecesCnt = await this.excrementsService.getExcrementsCount(journalId, dogId, EXCREMENT.Feces);
         const urineCnt = await this.excrementsService.getExcrementsCount(journalId, dogId, EXCREMENT.Urine);
-        if (!fecesCnt && !urineCnt) {
-            return;
-        }
-        //TODO: 없어도 0을 넣기
-        fecesCnt ? (excrementsInfo.fecesCnt = fecesCnt) : fecesCnt;
-        urineCnt ? (excrementsInfo.urineCnt = urineCnt) : urineCnt;
 
+        excrementsInfo.fecesCnt = fecesCnt;
+        excrementsInfo.urineCnt = urineCnt;
         return excrementsInfo;
     }
 

--- a/backend/src/journals/types/journal-detail.type.ts
+++ b/backend/src/journals/types/journal-detail.type.ts
@@ -71,6 +71,6 @@ export class JournalDetail {
     constructor(journalInfo: JournalInfoForDetail, dogInfo: DogInfoForDetail[], excrements: ExcrementsInfoForDetail[]) {
         this.journalInfo = journalInfo;
         this.dogs = dogInfo;
-        excrements.length ? (this.excrements = excrements) : excrements;
+        this.excrements = excrements;
     }
 }

--- a/backend/test/journals.e2e-spec.ts
+++ b/backend/test/journals.e2e-spec.ts
@@ -595,6 +595,7 @@ describe('JournalsController (e2e)', () => {
                     {
                         dogId: 2,
                         fecesCnt: 1,
+                        urineCnt: 0,
                     },
                 ],
             };

--- a/docs/journals/id.yaml
+++ b/docs/journals/id.yaml
@@ -155,6 +155,7 @@ get:
             required:
               - journalInfo
               - dogs
+              - excrements
     "401":
       description: Authorization header가 없거나 유효한 access token이 아닌 경우
     "403":


### PR DESCRIPTION
## 작업 내용 (Content)
산책일지 상세 조회시
해당하는 산책일지 & 강아지의 배변 기록이 없으면 아예 필드를 보내지 않았는데
0을 넣어 보내도록 변경했습니다.


## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
