### PR TITLE
backend/DANG-1159: DogsService, StatisticsService, UsersService TODO

### DIFF
--- a/backend/src/dog-walk-day/dog-walk-day.service.spec.ts
+++ b/backend/src/dog-walk-day/dog-walk-day.service.spec.ts
@@ -1,4 +1,3 @@
-import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { EntityManager, Repository, UpdateResult } from 'typeorm';
@@ -8,7 +7,7 @@ import { DogWalkDayRepository } from './dog-walk-day.repository';
 import { DogWalkDayService } from './dog-walk-day.service';
 
 import { WinstonLoggerService } from '../common/logger/winstonLogger.service';
-import { mockDogWalkDay, mockDogWalkDays } from '../fixtures/dogWalkDays.fixture';
+import { mockDogWalkDay } from '../fixtures/dogWalkDays.fixture';
 
 describe('DogWalkDayService', () => {
     let dogWalkDayService: DogWalkDayService;
@@ -30,48 +29,6 @@ describe('DogWalkDayService', () => {
 
         dogWalkDayService = module.get<DogWalkDayService>(DogWalkDayService);
         repository = module.get<Repository<DogWalkDay>>(getRepositoryToken(DogWalkDay));
-    });
-
-    describe('getWalkDayList', () => {
-        beforeEach(() => {
-            jest.spyOn(repository, 'find').mockResolvedValue(mockDogWalkDays);
-            jest.spyOn(dogWalkDayService, 'resetWeeklyCount').mockResolvedValue();
-        });
-
-        context('walkDayIds 값이 주어지면', () => {
-            it('WalkDay 요일별 값을 반환해야 한다.', async () => {
-                const dogWalkDays = await dogWalkDayService.getWalkDayList([1, 2]);
-
-                expect(dogWalkDays).toEqual([
-                    [2, 1, 3, 0, 4, 2, 1],
-                    [1, 2, 1, 3, 2, 1, 0],
-                ]);
-            });
-        });
-
-        context('빈 배열이 주어지면', () => {
-            beforeEach(() => {
-                jest.spyOn(repository, 'find').mockResolvedValue([]);
-            });
-
-            it('NotFoundException을 던져야 한다.', async () => {
-                await expect(dogWalkDayService.getWalkDayList([])).rejects.toThrow(
-                    new NotFoundException('walkDayIds에 값이 없습니다'),
-                );
-            });
-        });
-    });
-
-    context('존재하지 않는 id가 포함된 배열이 주어지면', () => {
-        beforeEach(() => {
-            jest.spyOn(repository, 'find').mockResolvedValue([]);
-        });
-
-        it('NotFoundException을 던져야 한다.', async () => {
-            await expect(dogWalkDayService.getWalkDayList([3, 4])).rejects.toThrow(
-                new NotFoundException('id가 3,4인 레코드를 찾을 수 없습니다'),
-            );
-        });
     });
 
     describe('updateDailyWalkCount', () => {

--- a/backend/src/dogs/dogs.service.ts
+++ b/backend/src/dogs/dogs.service.ts
@@ -154,19 +154,20 @@ export class DogsService {
         //TODO: key를 반환하는 함수 만들어 인자로 넣기
         return makeSubObjectsArray(dogs, ['id', 'name', 'profilePhotoUrl']);
     }
-    //TODO: DogSummary에 해당하는 컬럼을 애초에 select 해서 가져오기
+
     async getDogsSummaryList(where: FindOptionsWhere<Dogs>): Promise<DogSummary[]> {
-        const dogInfos = await this.dogsRepository.find({ where });
+        const dogInfos = await this.dogsRepository.find({ where, select: ['id', 'name', 'profilePhotoUrl'] });
         return this.makeDogsSummaryList(dogInfos);
     }
 
-    //TODO : makeProfile 함수로 하지 않고 애초에 select 해서 가져오기
     async getProfile(dogId: number): Promise<DogProfile> {
-        const dogInfo = await this.dogsRepository.findOne({ where: { id: dogId } });
+        const dogInfo = await this.dogsRepository.findOne({
+            where: { id: dogId },
+            select: ['id', 'name', 'breed', 'gender', 'isNeutered', 'birth', 'weight', 'profilePhotoUrl'],
+        });
         return this.makeProfile(dogInfo);
     }
 
-    //TODO: 쿼리 빌더를 쓸 것인지, 각자 테이블에서 가져와서 코드상으로 가공할 것인지 성능 테스트?
     async getProfileList(userId: number): Promise<DogProfile[]> {
         const dogProfiles = await this.entityManager
             .createQueryBuilder(Dogs, 'dogs')

--- a/backend/src/dogs/dogs.service.ts
+++ b/backend/src/dogs/dogs.service.ts
@@ -1,5 +1,5 @@
 import { ConflictException, Injectable } from '@nestjs/common';
-import { EntityManager, FindOneOptions, FindOptionsWhere, In } from 'typeorm';
+import { EntityManager, FindManyOptions, FindOneOptions, FindOptionsWhere, In } from 'typeorm';
 import { Transactional } from 'typeorm-transactional';
 
 import { Dogs } from './dogs.entity';
@@ -20,7 +20,7 @@ import { UsersService } from '../users/users.service';
 import { UsersDogs } from '../users-dogs/users-dogs.entity';
 import { UsersDogsService } from '../users-dogs/users-dogs.service';
 
-import { makeSubObjectsArray } from '../utils/manipulate.util';
+import { makeSubObject, makeSubObjectsArray } from '../utils/manipulate.util';
 
 @Injectable()
 export class DogsService {
@@ -102,6 +102,10 @@ export class DogsService {
         ]);
     }
 
+    async find(where: FindManyOptions<Dogs>): Promise<Dogs[]> {
+        return this.dogsRepository.find(where);
+    }
+
     async findOne(where: FindOneOptions<Dogs>) {
         return this.dogsRepository.findOne(where);
     }
@@ -139,14 +143,8 @@ export class DogsService {
 
     private makeProfile(dogInfo: Dogs): DogProfile {
         return {
-            id: dogInfo.id,
-            name: dogInfo.name,
+            ...makeSubObject(dogInfo, ['id', 'name', 'gender', 'isNeutered', 'birth', 'weight', 'profilePhotoUrl']),
             breed: dogInfo.breed.koreanName,
-            gender: dogInfo.gender,
-            isNeutered: dogInfo.isNeutered,
-            birth: dogInfo.birth,
-            weight: dogInfo.weight,
-            profilePhotoUrl: dogInfo.profilePhotoUrl,
         };
     }
 
@@ -169,14 +167,14 @@ export class DogsService {
     }
 
     async getProfileList(userId: number): Promise<DogProfile[]> {
-        const dogProfiles = await this.entityManager
+        const dogInfos = await this.entityManager
             .createQueryBuilder(Dogs, 'dogs')
             .innerJoin(UsersDogs, 'users_dogs', 'users_dogs.dogId = dogs.id')
             .innerJoinAndSelect('dogs.breed', 'breed')
             .where('users_dogs.userId = :userId', { userId })
             .getMany();
 
-        return dogProfiles.map((dog) => this.makeProfile(dog));
+        return dogInfos.map((dogInfo) => this.makeProfile(dogInfo));
     }
 
     async getRelatedTableIdList(

--- a/backend/src/fixtures/journals.fixture.ts
+++ b/backend/src/fixtures/journals.fixture.ts
@@ -112,7 +112,7 @@ export const mockJournalProfile = {
         {
             dogId: 2,
             fecesCnt: 1,
-            // TODO: urineCnt: 0이 더 자연스럽지 않나.. 논의해보기
+            urineCnt: 0,
         },
     ],
 };

--- a/backend/src/statistics/statistics.service.ts
+++ b/backend/src/statistics/statistics.service.ts
@@ -1,27 +1,25 @@
-import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { In } from 'typeorm';
 
 import { Period } from './pipes/period-validation.pipe';
 
 import { DogStatistic } from './types/statistic.type';
 
-import { BreedService } from '../breed/breed.service';
 import { WinstonLoggerService } from '../common/logger/winstonLogger.service';
 import { DogWalkDayService } from '../dog-walk-day/dog-walk-day.service';
 import { DogsService } from '../dogs/dogs.service';
-import { DogSummary } from '../dogs/types/dog-summary.type';
 import { JournalsService } from '../journals/journals.service';
 import { TodayWalkTimeService } from '../today-walk-time/today-walk-time.service';
 import { UsersService } from '../users/users.service';
 
 import { getOneMonthAgo, getStartAndEndOfMonth, getStartAndEndOfWeek } from '../utils/date.util';
+import { makeSubObject } from '../utils/manipulate.util';
 
 @Injectable()
 export class StatisticsService {
     constructor(
         private readonly usersService: UsersService,
         private readonly dogsService: DogsService,
-        private readonly breedService: BreedService,
         private readonly dogWalkDayService: DogWalkDayService,
         private readonly todayWalkTimeService: TodayWalkTimeService,
         private readonly journalsService: JournalsService,
@@ -54,59 +52,25 @@ export class StatisticsService {
         return this.journalsService.findJournalsAndAggregateByDay(userId, dogId, startDate, endDate);
     }
 
-    //TODO: select로 변경
-    private makeStatisticData(
-        dogProfiles: DogSummary[],
-        recommendedWalkAmount: number[],
-        todayWalkAmount: number[],
-        weeklyWalks: number[][],
-    ): DogStatistic[] {
-        const result: DogStatistic[] = [];
-
-        for (let i = 0; i < dogProfiles.length; i++) {
-            result.push({
-                id: dogProfiles[i].id,
-                name: dogProfiles[i].name,
-                profilePhotoUrl: dogProfiles[i].profilePhotoUrl,
-                recommendedWalkAmount: recommendedWalkAmount[i],
-                todayWalkAmount: todayWalkAmount[i],
-                weeklyWalks: weeklyWalks[i],
-            });
-        }
-
-        return result;
-    }
-
-    //TODO: 쿼리 빌더 만들어서 성능 비교
     async getDogsStatistics(userId: number): Promise<DogStatistic[]> {
         const ownDogIds = await this.usersService.getOwnDogsList(userId);
-        //TODO: 한번에 가져오게 select로 바꾸기
-        const dogWalkDayIds = await this.dogsService.getRelatedTableIdList(ownDogIds, 'walkDayId');
-        const todayWalkTimeIds = await this.dogsService.getRelatedTableIdList(ownDogIds, 'todayWalkTimeId');
-        const breedIds = await this.dogsService.getRelatedTableIdList(ownDogIds, 'breedId');
 
-        const dogSummaries = await this.dogsService.getDogsSummaryList({ id: In(ownDogIds) });
-        const recommendedWalkAmount = await this.breedService.getRecommendedWalkAmountList(breedIds);
-        const todayWalkAmount = await this.todayWalkTimeService.getWalkDurations(todayWalkTimeIds);
-        const weeklyWalks = await this.dogWalkDayService.getWalkDayList(dogWalkDayIds);
+        const ownDogInfos = await this.dogsService.find({
+            where: { id: In(ownDogIds) },
+            select: ['id', 'name', 'profilePhotoUrl', 'breed', 'todayWalkTime', 'walkDay'],
+            relations: {
+                walkDay: true,
+                todayWalkTime: true,
+            },
+        });
 
-        const length = ownDogIds.length;
-        const mismatchedLengths = [
-            dogSummaries.length !== length && `dogProfiles.length = ${dogSummaries.length}`,
-            recommendedWalkAmount.length !== length && `recommendedWalkAmount.length = ${recommendedWalkAmount.length}`,
-            todayWalkAmount.length !== length && `todayWalkAmount.length = ${todayWalkAmount.length}`,
-            weeklyWalks.length !== length && `weeklyWalks.length = ${weeklyWalks.length}`,
-        ].filter(Boolean);
-
-        if (mismatchedLengths.length > 0) {
-            const error = new NotFoundException(`dogId: ${ownDogIds}에 대한 데이터가 누락되었거나 일치하지 않습니다.`);
-            this.logger.error(
-                `dogId: ${ownDogIds}에 대한 데이터가 누락되었거나 일치하지 않습니다. 올바른 길이: ${length}. 일치하지 않는 데이터: ${mismatchedLengths.join(', ')}`,
-                { trace: error.stack ?? '스택 없음' },
-            );
-            throw error;
-        }
-
-        return this.makeStatisticData(dogSummaries, recommendedWalkAmount, todayWalkAmount, weeklyWalks);
+        return await Promise.all(
+            ownDogInfos.map(async (ownDogInfo) => ({
+                ...makeSubObject(ownDogInfo, ['id', 'name', 'profilePhotoUrl']),
+                recommendedWalkAmount: ownDogInfo.breed.recommendedWalkAmount,
+                todayWalkAmount: await this.todayWalkTimeService.updateIfStaleAndGetDuration(ownDogInfo.todayWalkTime),
+                weeklyWalks: await this.dogWalkDayService.updateIfStaleAndGetWeeklyWalks(ownDogInfo.walkDay),
+            })),
+        );
     }
 }

--- a/backend/src/statistics/statistics.service.ts
+++ b/backend/src/statistics/statistics.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { In } from 'typeorm';
 
 import { Period } from './pipes/period-validation.pipe';
@@ -28,29 +28,27 @@ export class StatisticsService {
         private readonly logger: WinstonLoggerService,
     ) {}
 
-    //TODO: Date 값 함수로 만들어서 반환 -> 유효하지 않은 period면 Error 던지기
     async getDogStatistics(userId: number, dogId: number, period: Period) {
-        let startDate: Date;
-        let endDate: Date;
-        startDate = endDate = new Date();
+        let startDate: Date, endDate: Date;
 
         if (period === 'month') {
-            startDate = getOneMonthAgo(new Date());
+            ({ startDate, endDate } = getOneMonthAgo(new Date()));
+        } else {
+            throw new BadRequestException(`유효하지 않은 period: ${period}`);
         }
 
         return this.journalsService.findJournalsAndGetTotal(userId, dogId, startDate, endDate);
     }
 
-    //TODO: Date 값 함수로 만들어서 반환 -> 유효하지 않은 period면 Error 던지기
     async getDogWalkCnt(userId: number, dogId: number, date: string, period: Period) {
-        let startDate: Date;
-        let endDate: Date;
-        startDate = endDate = new Date();
+        let startDate: Date, endDate: Date;
 
         if (period === 'month') {
             ({ startDate, endDate } = getStartAndEndOfMonth(new Date(date)));
         } else if (period === 'week') {
             ({ startDate, endDate } = getStartAndEndOfWeek(new Date(date)));
+        } else {
+            throw new BadRequestException(`유효하지 않은 period: ${period}`);
         }
 
         return this.journalsService.findJournalsAndAggregateByDay(userId, dogId, startDate, endDate);

--- a/backend/src/today-walk-time/today-walk-time.service.spec.ts
+++ b/backend/src/today-walk-time/today-walk-time.service.spec.ts
@@ -58,29 +58,6 @@ describe('ExcrementsService', () => {
         },
     ];
 
-    describe('getWalkDurations', () => {
-        beforeEach(() => {
-            jest.spyOn(todayWalkTimeRepository, 'find').mockImplementation(createMockFindImplementation());
-            jest.spyOn(todayWalkTimeRepository, 'update').mockResolvedValue({ affected: 1 } as UpdateResult);
-        });
-
-        context('특정 walkTimeIds가 주어지면', () => {
-            it('해당 ID들의 duration을 정확히 반환해야 한다.', async () => {
-                const excrements = await service.getWalkDurations([1, 2]);
-
-                expect(excrements).toEqual([4109, 5000]);
-            });
-        });
-
-        context('존재하지 않는 walkTimeId가 주어지면', () => {
-            it('NotFoundException 예외를 던져야 한다.', async () => {
-                await expect(service.getWalkDurations([0])).rejects.toThrow(
-                    new NotFoundException('id: 0와 일치하는 레코드가 없습니다'),
-                );
-            });
-        });
-    });
-
     describe('updateDurations', () => {
         beforeEach(() => {
             jest.spyOn(todayWalkTimeRepository, 'find').mockImplementation(createMockFindImplementation());

--- a/backend/src/today-walk-time/today-walk-time.service.ts
+++ b/backend/src/today-walk-time/today-walk-time.service.ts
@@ -19,12 +19,15 @@ export class TodayWalkTimeService {
         return this.todayWalkTimeRepository.delete(where);
     }
 
-    //TODO: 이름에 update 넣어서 명확하게 하기
-    private async checkDayPassed(walkTimeId: number, updatedAt: Date) {
+    async updateIfStaleAndGetDuration(todayWalkTime: TodayWalkTime): Promise<number> {
         const startOfToday = getStartOfToday();
-        if (updatedAt < startOfToday) {
-            await this.todayWalkTimeRepository.update({ id: walkTimeId }, { duration: 0 });
+
+        if (todayWalkTime.updatedAt < startOfToday) {
+            await this.todayWalkTimeRepository.update({ id: todayWalkTime.id }, { duration: 0 });
+            return 0;
         }
+
+        return todayWalkTime.duration;
     }
 
     async updateDurations(
@@ -49,25 +52,6 @@ export class TodayWalkTimeService {
                 return this.todayWalkTimeRepository.update({ id: walkTime.id }, { duration: updateDuration });
             }),
         );
-    }
-
-    async getWalkDurations(walkTimeIds: number[]): Promise<number[]> {
-        const todayWalkTimes = await this.findWalkTimesByIds(walkTimeIds);
-        if (!todayWalkTimes.length) {
-            const error = new NotFoundException(`id: ${walkTimeIds}와 일치하는 레코드가 없습니다`);
-            this.logger.error(`id: ${walkTimeIds}와 일치하는 레코드가 없습니다`, {
-                trace: error.stack ?? '스택 없음',
-            });
-            throw error;
-        }
-        //TODO: batch 업데이트 되게 바꾸기
-        for (const currentTodayWalk of todayWalkTimes) {
-            await this.checkDayPassed(currentTodayWalk.id, currentTodayWalk.updatedAt);
-        }
-
-        return todayWalkTimes.map((todayWalkTime) => {
-            return todayWalkTime.duration;
-        });
     }
 
     private async findWalkTimesByIds(walkTimeIds: number[]): Promise<TodayWalkTime[]> {

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -66,22 +66,23 @@ export class UsersService {
     }
 
     async getOwnDogsList(userId: number): Promise<number[]> {
-        //TODO: select로 변경
-        const foundDogs = await this.usersDogsService.find({ where: { userId } });
-        return foundDogs.map((cur) => cur.dogId);
+        return (await this.usersDogsService.find({ where: { userId }, select: ['dogId'] })).map((cur) => cur.dogId);
     }
 
     async checkDogOwnership(userId: number, dogId: number | number[]): Promise<[boolean, number[]]> {
-        //TODO: select로 변경
-        const ownDogs = await this.usersDogsService.find({ where: { userId } });
-        const myDogIds = ownDogs.map((cur) => cur.dogId);
+        const myDogIds = (await this.usersDogsService.find({ where: { userId }, select: ['dogId'] })).map(
+            (cur) => cur.dogId,
+        );
 
         return checkIfExistsInArr(myDogIds, dogId);
     }
 
     async getUserProfile({ userId, provider }: AccessTokenPayload): Promise<UserProfile> {
-        //TODO: select로 변경
-        const { nickname, email, profileImageUrl } = await this.usersRepository.findOne({ where: { id: userId } });
+        const { nickname, email, profileImageUrl } = await this.usersRepository.findOne({
+            where: { id: userId },
+            select: ['nickname', 'email', 'profileImageUrl'],
+        });
+
         return { nickname, email, profileImageUrl, provider };
     }
 

--- a/backend/src/utils/date.util.spec.ts
+++ b/backend/src/utils/date.util.spec.ts
@@ -57,9 +57,10 @@ describe('getStartAndEndOfDay', () => {
 describe('getOneMonthAgo', () => {
     it('주어진 날짜로부터 한 달 전의 정확한 날짜를 반환한다', () => {
         const date = new Date('2024-03-01');
-        const oneMonthAgoDate = getOneMonthAgo(date);
+        const { startDate, endDate } = getOneMonthAgo(date);
 
-        expect(formatDate(oneMonthAgoDate)).toBe('2024-02-01');
+        expect(formatDate(startDate)).toBe('2024-02-01');
+        expect(formatDate(endDate)).toBe('2024-03-01');
     });
 });
 

--- a/backend/src/utils/date.util.ts
+++ b/backend/src/utils/date.util.ts
@@ -12,7 +12,12 @@ export function getWeekNumber(date: Date): number {
     return Math.ceil((currentDate + firstDay) / 7);
 }
 
-export function getStartAndEndOfMonth(date: Date): { startDate: Date; endDate: Date } {
+interface DateRange {
+    startDate: Date;
+    endDate: Date;
+}
+
+export function getStartAndEndOfMonth(date: Date): DateRange {
     const startDate = new Date(date);
     startDate.setDate(1);
     startDate.setHours(0, 0, 0, 0);
@@ -25,7 +30,7 @@ export function getStartAndEndOfMonth(date: Date): { startDate: Date; endDate: D
     return { startDate, endDate };
 }
 
-export function getStartAndEndOfWeek(date: Date): { startDate: Date; endDate: Date } {
+export function getStartAndEndOfWeek(date: Date): DateRange {
     const startDate = new Date(date);
     startDate.setDate(startDate.getDate() - startDate.getDay());
     startDate.setHours(0, 0, 0, 0);
@@ -37,7 +42,7 @@ export function getStartAndEndOfWeek(date: Date): { startDate: Date; endDate: Da
     return { startDate, endDate };
 }
 
-export function getStartAndEndOfDay(date: Date): { startDate: Date; endDate: Date } {
+export function getStartAndEndOfDay(date: Date): DateRange {
     const startDate = new Date(date);
     startDate.setHours(0, 0, 0, 0);
 
@@ -47,10 +52,13 @@ export function getStartAndEndOfDay(date: Date): { startDate: Date; endDate: Dat
     return { startDate, endDate };
 }
 
-export function getOneMonthAgo(date: Date): Date {
-    const oneMonthAgo = new Date(date);
-    oneMonthAgo.setMonth(date.getMonth() - 1);
-    return oneMonthAgo;
+export function getOneMonthAgo(date: Date): DateRange {
+    const startDate = new Date(date);
+    startDate.setMonth(date.getMonth() - 1);
+
+    const endDate = new Date(date);
+
+    return { startDate, endDate };
 }
 
 export function getLastSunday() {


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- select option을 추가해 가져올 열 명시
- 수정된 excrements 동작에 맞게 journals fixture 변경 (`urineCnt: 0`,)
- 날짜 범위를 가져오는 함수의 반환 타입을 `{ startDate, endDate }`으로 통일 및 period 예외 처리
- `dogsService`에서 `makeSubObject`를 활용해 `makeProfile` method 간소화, `find` method 추가
- 강아지 통계 method 개선 
  - 기존에는 필요한 data를 모두 개별적인 query를 실행해 비효율적으로 가져왔었다.
  - 단일 query를 사용해 필요한 정보를 모두 가져온 후 가공한다.
  - 하루 산책 시간과 일주일 산책 횟수의 경우 조회 시 오래된 data인 경우 초기화를 하는 logic이 필요하므로 따로 method를 만들어 사용했다.

## 링크 (Links)
https://www.notion.so/do0ori/DogsService-StatisticsService-UsersService-TODO-ffe0ded760c846c69821e5dbbc134ec7

## 기타 사항 (Etc)
https://www.notion.so/do0ori/Join-select-data-9e701eda49b5446f9e8129247dabe7ba

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
