### PR TITLE
backend/DANG-1161: 더 이상 사용하지 않는 DATA_SIZE 변수 제거

### DIFF
--- a/backend/test/performance/response-time.ts
+++ b/backend/test/performance/response-time.ts
@@ -23,15 +23,11 @@ const runPostmanCollectionWithNewman = async (
     }
 };
 
-const DATA_SIZE = parseInt(process.env.DATA_SIZE!);
 const COLLECTION_ID = process.env.COLLECTION_ID!;
 const REQUEST_OR_FOLDER_ID = process.env.REQUEST_OR_FOLDER_ID!;
 const ITERATION_COUNT = parseInt(process.env.ITERATION_COUNT!);
 
 const validateParameters = () => {
-    if (isNaN(DATA_SIZE)) {
-        throw new Error('DATA_SIZE가 정의되지 않았거나 유효한 숫자가 아닙니다. .env.test 파일을 수정해주세요.');
-    }
     if (!COLLECTION_ID) {
         throw new Error('COLLECTION_ID가 정의되지 않았습니다. .env.test 파일을 수정해주세요.');
     }


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
test data 삽입, 삭제 script를 분리하면서 API 응답 속도 측정 script에서 DATA_SIZE 변수를 사용할 필요가 없어졌다.

## 링크 (Links)
https://www.notion.so/do0ori/API-script-DATA_SIZE-4c84c8b91351421b8a727c2bb42d9ffb

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
