### PR TITLE
backend/DANG-1158: 산책일지 상세 API 성능 개선

### DIFF
--- a/backend/src/common/database/abstract.repository.ts
+++ b/backend/src/common/database/abstract.repository.ts
@@ -61,7 +61,13 @@ export abstract class AbstractRepository<T extends ObjectLiteral> {
     }
 
     async find(where: FindManyOptions<T>): Promise<T[]> {
-        return this.entityRepository.find(where);
+        const result = this.entityRepository.find(where);
+
+        if (!result) {
+            throw new NotFoundException('findOne: Entity not found');
+        }
+
+        return result;
     }
 
     async update(where: FindOptionsWhere<T>, partialEntity: QueryDeepPartialEntity<T>): Promise<UpdateResult> {

--- a/backend/src/excrements/excrements.service.spec.ts
+++ b/backend/src/excrements/excrements.service.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { EntityManager, FindManyOptions, Repository } from 'typeorm';
+import { EntityManager, Repository } from 'typeorm';
 
 import { Excrements } from './excrements.entity';
 import { ExcrementsRepository } from './excrements.repository';
@@ -8,8 +8,7 @@ import { ExcrementsService } from './excrements.service';
 import { FakeExcrementsService } from './fake-excrements.service';
 
 describe('ExcrementsService', () => {
-    let service: ExcrementsService;
-    let excrementsRepository: Repository<Excrements>;
+    let excrementsService: ExcrementsService;
 
     beforeEach(async () => {
         const module: TestingModule = await Test.createTestingModule({
@@ -27,80 +26,13 @@ describe('ExcrementsService', () => {
             ],
         }).compile();
 
-        service = module.get<ExcrementsService>(ExcrementsService);
-        excrementsRepository = module.get<Repository<Excrements>>(getRepositoryToken(Excrements));
-    });
-
-    describe('getExcrementsCount', () => {
-        const mockExcrements: Excrements[] = [
-            new Excrements({
-                journalId: 1,
-                dogId: 1,
-                type: 'URINE',
-                coordinate: 'POINT(126.977948 37.566667)',
-            }),
-            new Excrements({
-                journalId: 1,
-                dogId: 1,
-                type: 'FECES',
-                coordinate: 'POINT(12.4924 41.8902)',
-            }),
-            new Excrements({
-                journalId: 1,
-                dogId: 1,
-                type: 'FECES',
-                coordinate: 'POINT(12.4924 41.8902)',
-            }),
-        ];
-
-        beforeEach(() => {
-            jest.spyOn(excrementsRepository, 'find').mockImplementation((options?: FindManyOptions<Excrements>) => {
-                if (!options?.where) {
-                    return Promise.resolve(mockExcrements);
-                }
-
-                const { journalId, dogId, type } = options.where as Record<string, unknown>;
-
-                return Promise.resolve(
-                    mockExcrements.filter(
-                        (excrement) =>
-                            (journalId === undefined || excrement.journalId === journalId) &&
-                            (dogId === undefined || excrement.dogId === dogId) &&
-                            (type === undefined || excrement.type === type),
-                    ),
-                );
-            });
-        });
-
-        context('특정 journalId와 dogId에 대해 Type이 FECES인 경우', () => {
-            it('해당 조건의 대변 기록 수를 정확히 반환해야 한다.', async () => {
-                const excrements = await service.getExcrementsCount(1, 1, 'FECES');
-
-                expect(excrements).toBe(2);
-            });
-        });
-
-        context('특정 journalId와 dogId에 대해 Type이 URINE인 경우', () => {
-            it('해당 조건의 소변 기록 수를 정확히 반환해야 한다', async () => {
-                const excrements = await service.getExcrementsCount(1, 1, 'URINE');
-
-                expect(excrements).toBe(1);
-            });
-        });
-
-        context('존재하지 않는 journalId, dogId, 또는 일치하지 않는 Type으로 조회할 때', () => {
-            it('배변 기록이 없으므로 0을 반환해야 한다', async () => {
-                const excrements = await service.getExcrementsCount(999, 99, 'URINE');
-
-                expect(excrements).toBe(0);
-            });
-        });
+        excrementsService = module.get<ExcrementsService>(ExcrementsService);
     });
 
     describe('createNewExcrements', () => {
         context('유효한 데이터로 새로운 배변 기록을 생성할 때', () => {
             it('속성을 가진 새로운 Excrements 객체를 반환해야 한다', async () => {
-                const excrements = await service.createNewExcrements(1, 1, 'FECES', {
+                const excrements = await excrementsService.createNewExcrements(1, 1, 'FECES', {
                     lat: '126.9780',
                     lng: '37.5665',
                 });

--- a/backend/src/excrements/fake-excrements.service.ts
+++ b/backend/src/excrements/fake-excrements.service.ts
@@ -1,13 +1,15 @@
 import { Injectable } from '@nestjs/common';
 
+import { EntityManager } from 'typeorm';
+
 import { Excrements } from './excrements.entity';
 import { ExcrementsRepository } from './excrements.repository';
 import { ExcrementsService } from './excrements.service';
 
 @Injectable()
 export class FakeExcrementsService extends ExcrementsService {
-    constructor(excrementsRepository: ExcrementsRepository) {
-        super(excrementsRepository);
+    constructor(excrementsRepository: ExcrementsRepository, entityManager: EntityManager) {
+        super(excrementsRepository, entityManager);
     }
 
     async createIfNotExists(data: Partial<Excrements>): Promise<Excrements> {

--- a/backend/src/journal-photos/journal-photos.service.ts
+++ b/backend/src/journal-photos/journal-photos.service.ts
@@ -35,12 +35,18 @@ export class JournalPhotosService {
             await this.createIfNotExists(data, keys);
         }
     }
+    makePhotoUrls(photoUrlsRaw: Partial<JournalPhotos[]>): string[] {
+        return photoUrlsRaw.map((cur) => {
+            cur = cur as JournalPhotos;
+            return cur.photoUrl;
+        });
+    }
 
     //TODO: map을 쓰지 않도록 select 조건 추가하기
     async getPhotoUrlsByJournalId(journalId: number): Promise<string[]> {
-        const findResult = await this.journalPhotosRepository.find({ where: { journalId } });
-        return findResult.map((cur) => {
-            return cur.photoUrl;
+        const photoUrlsRaw: Partial<JournalPhotos[]> = await this.journalPhotosRepository.find({
+            where: { journalId },
         });
+        return this.makePhotoUrls(photoUrlsRaw);
     }
 }

--- a/backend/src/journal-photos/journal-photos.service.ts
+++ b/backend/src/journal-photos/journal-photos.service.ts
@@ -46,6 +46,7 @@ export class JournalPhotosService {
     async getPhotoUrlsByJournalId(journalId: number): Promise<string[]> {
         const photoUrlsRaw: Partial<JournalPhotos[]> = await this.journalPhotosRepository.find({
             where: { journalId },
+            select: ['photoUrl'],
         });
         return this.makePhotoUrls(photoUrlsRaw);
     }

--- a/backend/src/journals/types/journal-detail.type.ts
+++ b/backend/src/journals/types/journal-detail.type.ts
@@ -1,8 +1,11 @@
-import { IsNotEmpty, IsNumber, IsOptional, IsString } from 'class-validator';
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
 import { Dogs } from 'src/dogs/dogs.entity';
 
+import { Excrement } from 'src/excrements/types/excrement.type';
+
 import { Journals } from '../journals.entity';
+
 
 export class PhotoUrlType {
     @IsNotEmpty()
@@ -30,18 +33,26 @@ export class DogInfoForDetail {
         return ['id', 'name', 'profilePhotoUrl'];
     }
 }
+export class ExcrementsCount {
+    dogId: number;
+    type: Excrement;
+    count: number;
+}
 
 export class ExcrementsInfoForDetail {
-    @IsNotEmpty()
     dogId: number;
 
-    @IsOptional()
-    @IsNumber()
     fecesCnt: number;
 
-    @IsOptional()
-    @IsNumber()
     urineCnt: number;
+
+    constructor() {
+        return {
+            dogId: 0,
+            fecesCnt: 0,
+            urineCnt: 0,
+        };
+    }
 }
 
 export class JournalInfoForDetail {


### PR DESCRIPTION
## 작업 내용 (Content)

산책일지 상세 성능 개선
- 참여한 강아지들의 정보를 가져올 때 `where : IN` 을 사용해 한 번의 쿼리로
  조회할 수 있도록 변경
- dog_id, type별로 배변량의 count를 계산하는 쿼리를 사용해 한 번의
  쿼리로 조회할 수 있도록 변경
- `Promise.all`로 순서가 중요하지 않은 쿼리는 병렬 처리
- journal_photos 테이블 조회시 `select` 옵션으로 열 명시

기타
- abstract repository의 find 메소드에 404 예외처리 추가

## 링크 (Links)
https://www.notion.so/do0ori/ef1d009e3eaa4f619dbc9050197e8b41?pvs=4
## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
