### PR TITLE
backend/DANG-1166: AbstractRepository 예외 메세지 영어 -> 한글로 수정

### DIFF
--- a/backend/src/common/database/abstract.repository.ts
+++ b/backend/src/common/database/abstract.repository.ts
@@ -40,7 +40,7 @@ export abstract class AbstractRepository<T extends ObjectLiteral> {
         const existingEntity = await this.entityRepository.findOne({ where });
 
         if (existingEntity) {
-            throw new ConflictException('createIfNotExists: Duplicate entry');
+            throw new ConflictException('createIfNotExists: 이미 존재하는 레코드입니다');
         }
 
         return this.create(entity);
@@ -54,7 +54,7 @@ export abstract class AbstractRepository<T extends ObjectLiteral> {
         const entity = await this.entityRepository.findOne(where);
 
         if (!entity) {
-            throw new NotFoundException('findOne: Entity not found');
+            throw new NotFoundException('findOne: 존재하지 않는 레코드입니다');
         }
 
         return entity;
@@ -64,7 +64,7 @@ export abstract class AbstractRepository<T extends ObjectLiteral> {
         const result = this.entityRepository.find(where);
 
         if (!result) {
-            throw new NotFoundException('findOne: Entity not found');
+            throw new NotFoundException('find: 존재하지 않는 레코드입니다');
         }
 
         return result;
@@ -74,7 +74,7 @@ export abstract class AbstractRepository<T extends ObjectLiteral> {
         const updateResult = await this.entityRepository.update(where, partialEntity);
 
         if (!updateResult.affected) {
-            throw new NotFoundException('update: Entity not found');
+            throw new NotFoundException('update: 존재하지 않는 레코드입니다');
         }
 
         return updateResult;
@@ -84,7 +84,7 @@ export abstract class AbstractRepository<T extends ObjectLiteral> {
         const deleteResult = await this.entityRepository.delete(where);
 
         if (!deleteResult.affected) {
-            throw new NotFoundException('delete: Entity not found');
+            throw new NotFoundException('delete: 존재하지 않는 레코드입니다');
         }
 
         return deleteResult;
@@ -94,7 +94,7 @@ export abstract class AbstractRepository<T extends ObjectLiteral> {
         const updateResult = await this.entityRepository.update(where, partialEntity);
 
         if (!updateResult.affected) {
-            throw new NotFoundException('update: Entity not found');
+            throw new NotFoundException('update: 존재하지 않는 레코드입니다');
         }
         const options: FindOneOptions = { where };
 


### PR DESCRIPTION
## 작업 내용 (Content)
- 기존 영어 예외 메세지는 'Entity not found'라고 되어있었는데, 
Entity라는 표현이 적합하지 않은 것 같아 레코드로 단어를 바꾸었습니다.

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
