### PR TITLE
backend/DANG-898: Token 재발급 API에서 select option 사용 및 oauthId Index 추가

### DIFF
--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -95,7 +95,10 @@ export class AuthService {
     }
 
     async reissueTokens({ oauthId, provider }: RefreshTokenPayload): Promise<AuthData> {
-        const { id: userId, oauthRefreshToken } = await this.usersService.findOne({ where: { oauthId } });
+        const { id: userId, oauthRefreshToken } = await this.usersService.findOne({
+            where: { oauthId },
+            select: ['id', 'oauthRefreshToken'],
+        });
 
         const [
             { access_token: newOauthAccessToken, refresh_token: newOauthRefreshToken },

--- a/backend/src/users/users.entity.ts
+++ b/backend/src/users/users.entity.ts
@@ -32,7 +32,6 @@ export class Users {
     @Column({ name: 'main_dog_id', nullable: true })
     mainDogId: number | null;
 
-    //TODO: 인덱스 테스트
     @Column({ name: 'oauth_id', unique: true })
     oauthId: string;
 

--- a/backend/test/performance/__mocks__/auth.service.ts
+++ b/backend/test/performance/__mocks__/auth.service.ts
@@ -1,0 +1,10 @@
+import * as jwt from 'jsonwebtoken';
+
+import { AuthService } from '../../../src/auth/auth.service';
+import { RefreshTokenPayload } from '../../../src/auth/token/token.service';
+
+export class MockAuthService extends AuthService {
+    async validateRefreshToken(token: string) {
+        return jwt.verify(token, process.env.JWT_SECRET!) as RefreshTokenPayload;
+    }
+}

--- a/backend/test/performance/utils/testApp.util.ts
+++ b/backend/test/performance/utils/testApp.util.ts
@@ -8,11 +8,13 @@ import { Transactional, initializeTransactionalContext } from 'typeorm-transacti
 import { CreateMockEntity } from './createMockEntity.util';
 
 import { AppModule } from '../../../src/app.module';
+import { AuthService } from '../../../src/auth/auth.service';
 import { GoogleService } from '../../../src/auth/oauth/google.service';
 import { KakaoService } from '../../../src/auth/oauth/kakao.service';
 import { NaverService } from '../../../src/auth/oauth/naver.service';
 import { S3Service } from '../../../src/s3/s3.service';
 import { color } from '../../../src/utils/ansi.util';
+import { MockAuthService } from '../__mocks__/auth.service';
 import { MockOauthService } from '../__mocks__/oauth.service';
 import { MockS3Service } from '../__mocks__/s3.service';
 
@@ -34,6 +36,8 @@ export class TestApp {
             .useValue(MockOauthService)
             .overrideProvider(S3Service)
             .useValue(MockS3Service)
+            .overrideProvider(AuthService)
+            .useClass(MockAuthService)
             .compile();
 
         this.app = moduleFixture.createNestApplication();


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- index 사용 전/후 성능 비교
- token 재발급 API 응답 시간 테스트를 위해 auth service mock 추가

## 링크 (Links)
https://www.notion.so/do0ori/Token-API-select-option-oauthId-Index-5a2bae7e99a549a3a82156de78ad217a

## 기타 사항 (Etc)
https://www.notion.so/do0ori/Index-e33b1e9fbde242128aa21ea81259fa78

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
