### PR TITLE
backend/DANG-1175: 트랜잭션에 적용된 Promise.all 삭제

### DIFF
--- a/backend/src/dogs/dogs.service.ts
+++ b/backend/src/dogs/dogs.service.ts
@@ -71,12 +71,11 @@ export class DogsService {
             throw error;
         }
 
-        await Promise.all([
-            this.dogWalkDayService.delete({ id: dog.walkDayId }),
-            this.todayWalkTimeService.delete({ id: dog.todayWalkTimeId }),
-            dog.profilePhotoUrl ? this.s3Service.deleteSingleObject(userId, dog.profilePhotoUrl) : Promise.resolve(),
-        ]);
-
+        await this.dogWalkDayService.delete({ id: dog.walkDayId });
+        await this.todayWalkTimeService.delete({ id: dog.todayWalkTimeId });
+        if (dog.profilePhotoUrl) {
+            await this.s3Service.deleteSingleObject(userId, dog.profilePhotoUrl);
+        }
         return dog;
     }
 

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -36,7 +36,8 @@ export class UsersService {
     }
 
     async delete(userId: number) {
-        await Promise.all([this.usersRepository.delete({ id: userId }), this.s3Service.deleteObjectFolder(userId)]);
+        await this.usersRepository.delete({ id: userId });
+        await this.s3Service.deleteObjectFolder(userId);
     }
 
     async createIfNotExists({ oauthNickname, ...otherAttributes }: CreateUser) {


### PR DESCRIPTION
- 트랜잭션 안에서는 Promise.all을 사용해도 병렬 처리가 안되어 삭제했습니다.

## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->

## 링크 (Links)
https://jojoldu.tistory.com/639

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
