### PR TITLE
backend/DANG-1185:  산책일지 목록 쿼리 리팩토링

### DIFF
--- a/backend/src/journals/types/journal-info.type.ts
+++ b/backend/src/journals/types/journal-info.type.ts
@@ -1,7 +1,5 @@
 import { IsDate, IsInt, IsNumber } from 'class-validator';
 
-import { Journals } from '../journals.entity';
-
 export class JournalInfoForList {
     @IsNumber()
     journalId: number;
@@ -21,11 +19,7 @@ export class JournalInfoForList {
     @IsNumber()
     duration: number;
 
-    static getAttributesForJournalTable() {
-        return ['journalId', 'startedAt', 'distance', 'calories', 'duration'];
-    }
-
-    static getKeysForJournalTable(): Array<keyof Journals> {
-        return ['id', 'startedAt', 'distance', 'calories', 'duration'];
+    static getKeysForJournalInfoResponse() {
+        return ['journalId', 'startedAt', 'distance', 'calories', 'duration', 'journalCnt'];
     }
 }


### PR DESCRIPTION
몇번째 산책일지인지 계산하기 위해 
journals_dogs에서 해당 강아지의 산책일지를 모두 가져온 뒤 
조건에 맞는 산책일지의 위치를 findIndex로 찾아오던 로직을,
getJournalIdsByDogIdAndDate 함수의 서브쿼리로 처리해 
하나의 쿼리에서 해결할 수 있도록 변경했습니다.

## 작업 내용 (Content)

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
