### PR TITLE
backend/DANG-1187: 좌표 타입 number 배열로 수정

### DIFF
--- a/backend/rest-api/journals/journals.http
+++ b/backend/rest-api/journals/journals.http
@@ -13,10 +13,8 @@ Content-Type: application/json
     "startedAt": "2024-06-25T16:41:44.586Z",
     "duration": 3600,
     "routes": [
-      {
-        "lat": 303,
-        "lng": 100
-      }
+      [ 10, 10.12 ],
+      [ 30.4, 180 ]
     ],
     "photoUrls": [
       "/1/sdofijwoejf.jpg"
@@ -27,16 +25,12 @@ Content-Type: application/json
     {
       "dogId": 2,
       "fecesLocations": [
-        {
-          "lat": "75.23",
-          "lng": "104.4839"
-        }
+        [ 10, 10.12 ],
+        [ 30.4, 180 ]
       ],
       "urineLocations": [
-        {
-          "lat": "202",
-          "lng": "120"
-        }
+        [ 10, 10.12 ],
+        [ 30.4, 180 ]
       ]
     }
   ]

--- a/backend/src/excrements/excrements.service.ts
+++ b/backend/src/excrements/excrements.service.ts
@@ -32,7 +32,7 @@ export class ExcrementsService {
             .getRawMany();
     }
 
-    makeCoordinate(lat: string, lng: string): string {
-        return `POINT(${lat} ${lng})`;
+    makeCoordinate(lat: number, lng: number): string {
+        return `POINT(${lat.toString()} ${lng.toString()})`;
     }
 }

--- a/backend/src/excrements/fake-excrements.service.ts
+++ b/backend/src/excrements/fake-excrements.service.ts
@@ -28,7 +28,7 @@ export class FakeExcrementsService extends ExcrementsService {
         return Promise.resolve(expectedExcrement);
     }
 
-    makeCoordinate(lat: string, lng: string): string {
+    makeCoordinate(lat: number, lng: number): string {
         return `POINT(${lat} ${lng})`;
     }
 }

--- a/backend/src/journals/dtos/create-journal.dto.ts
+++ b/backend/src/journals/dtos/create-journal.dto.ts
@@ -13,38 +13,15 @@ import {
 
 import { IsWGS84 } from '../validators/WGS84.validator';
 
-export class Location {
-    @IsWGS84({ message: 'The provided point is not in WGS84 format' })
-    @IsString()
-    lat: string;
-
-    @IsWGS84({ message: 'The provided point is not in WGS84 format' })
-    @IsString()
-    lng: string;
-}
-
-//TODO: GeoJSON으로 넘어가기 전 임시로 사용
-export class journalLocation {
-    @IsNumber()
-    lat: number;
-
-    @IsNumber()
-    lng: number;
-}
-
 export class ExcrementsInfoForCreate {
     @IsNotEmpty()
     dogId: number;
 
-    @IsArray()
-    @ValidateNested()
-    @Type(() => Location)
-    fecesLocations: Location[];
+    @IsWGS84()
+    fecesLocations: [number, number][];
 
-    @IsArray()
-    @ValidateNested()
-    @Type(() => Location)
-    urineLocations: Location[];
+    @IsWGS84()
+    urineLocations: [number, number][];
 }
 
 export class JournalInfoForCreate {
@@ -68,10 +45,8 @@ export class JournalInfoForCreate {
     @Min(0)
     duration: number;
 
-    @IsArray()
-    @ValidateNested()
-    @Type(() => journalLocation)
-    routes: journalLocation[];
+    @IsWGS84()
+    routes: [number, number][];
 
     @IsOptional()
     @IsString()

--- a/backend/src/journals/journals.service.ts
+++ b/backend/src/journals/journals.service.ts
@@ -179,12 +179,12 @@ export class JournalsService {
                 journalId: number,
                 dogId: number,
                 type: Excrement,
-                coordinate: { lat: string; lng: string },
+                coordinate: [number, number],
             ) => ({
                 journalId,
                 dogId,
                 type,
-                coordinate: this.excrementsService.makeCoordinate(coordinate.lat, coordinate.lng),
+                coordinate: this.excrementsService.makeCoordinate(coordinate[0], coordinate[1]),
             });
 
             excrementsEntity.push(

--- a/backend/src/journals/types/create-journal-data.type.ts
+++ b/backend/src/journals/types/create-journal-data.type.ts
@@ -1,10 +1,9 @@
-import { Location, journalLocation } from '../dtos/create-journal.dto';
 import { Journals } from '../journals.entity';
 
 export interface CreateExcrementsInfo {
     dogId: number;
-    fecesLocations: Location[];
-    urineLocations: Location[];
+    fecesLocations: [number, number][];
+    urineLocations: [number, number][];
 }
 
 export class CreateJournalInfo {
@@ -12,7 +11,7 @@ export class CreateJournalInfo {
     calories: number;
     startedAt: Date;
     duration: number;
-    routes: journalLocation[];
+    routes: [number, number][];
     memo: string;
     photoUrls: string[];
 

--- a/backend/src/journals/validators/WGS84.validator.ts
+++ b/backend/src/journals/validators/WGS84.validator.ts
@@ -1,4 +1,5 @@
 import {
+    ValidationArguments,
     ValidationOptions,
     ValidatorConstraint,
     ValidatorConstraintInterface,
@@ -8,8 +9,49 @@ import {
 @ValidatorConstraint({ async: false })
 export class IsWGS84Constraint implements ValidatorConstraintInterface {
     private regexWgs84 = /^-?\d+\.*\d*/;
-    validate(point: string): boolean {
-        return this.regexWgs84.test(point);
+
+    private checkWGS84Range(coord: number, type: 'lat' | 'lng'): boolean {
+        if (type == 'lat') {
+            return coord >= -90 && coord <= 90;
+        } else {
+            return coord >= -180 && coord <= 180;
+        }
+    }
+
+    private isValidateCoordinate(coord: number, type: 'lat' | 'lng'): boolean {
+        if (typeof coord !== 'number' || !this.regexWgs84.test(coord.toString())) {
+            return false;
+        }
+
+        return this.checkWGS84Range(coord, type);
+    }
+
+    validate(value: [number, number][]): boolean {
+        if (!Array.isArray(value)) {
+            return false;
+        }
+
+        for (const cur of value) {
+            if (!Array.isArray(cur) || cur.length !== 2) {
+                return false;
+            }
+            return this.isValidateCoordinate(cur[0], 'lat') && this.isValidateCoordinate(cur[1], 'lng');
+        }
+        return true;
+    }
+
+    defaultMessage(validationArguments?: ValidationArguments | undefined): string {
+        if (validationArguments) {
+            for (const cur of validationArguments.value) {
+                if (typeof cur[0] !== 'number' || typeof cur[1] !== 'number') {
+                    return '요소의 타입이 number가 아닙니다';
+                }
+                if (!this.checkWGS84Range(cur[0], 'lat') || !this.checkWGS84Range(cur[1], 'lng')) {
+                    return 'WGS84 범위를 벗어나는 숫자입니다. lat : -90 ~ 90, lng: -180 ~ 180';
+                }
+            }
+        }
+        return 'WGS84 포맷을 따르는 number로 이루어진 길이 2의 배열이어야 합니다';
     }
 }
 


### PR DESCRIPTION
## 작업 내용 (Content)
산책 경로(routes) , 배변량(excrements)에 사용되는 좌표 타입의 크기를 줄이기 위해
{lat: number/string, lng: number/string}[]에서
[number, number][]로 변경하였습니다

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
