### PR TITLE
backend/DANG-1184: findUserDogJournalsByDate 쿼리 성능 개선

### DIFF
--- a/backend/src/journals/journals.entity.ts
+++ b/backend/src/journals/journals.entity.ts
@@ -1,8 +1,9 @@
-import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, Entity, Index, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
 
 import { Users } from '../users/users.entity';
 
 @Entity('journals')
+@Index(['userId', 'startedAt'])
 export class Journals {
     @PrimaryGeneratedColumn()
     id: number;

--- a/backend/src/journals/journals.service.ts
+++ b/backend/src/journals/journals.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { Excrements } from 'src/excrements/excrements.entity';
 import { DeleteResult, EntityManager, FindOptionsWhere, In, InsertResult } from 'typeorm';
 import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
@@ -15,7 +15,7 @@ import {
     JournalInfoForDetail,
 } from './types/journal-detail.type';
 
-import { JournalInfoForList } from './types/journal-info.type';
+import { DogWalkJournalEntry, JournalInfoForList } from './types/journal-info.type';
 import { UpdateJournalData, UpdateTodayWalkTimeOperation } from './types/update-journal-data.type';
 
 import { DogWalkDayService } from '../dog-walk-day/dog-walk-day.service';
@@ -258,18 +258,26 @@ export class JournalsService {
         dogId: number,
         startDate: Date,
         endDate: Date,
-    ): Promise<Journals[]> {
-        return await this.entityManager
-            .createQueryBuilder(Journals, 'journals')
-            .innerJoin(JournalsDogs, 'journals_dogs', 'journals.id = journals_dogs.journal_id')
-            .where('journals.user_id = :userId', { userId })
-            .andWhere('journals_dogs.dog_id = :dogId', { dogId })
-            .andWhere('journals.started_at >= :startDate', { startDate })
-            .andWhere('journals.started_at < :endDate', { endDate })
-            .getMany();
+    ): Promise<DogWalkJournalEntry[]> {
+        return await this.entityManager.query(
+            `
+        SELECT STRAIGHT_JOIN journals.distance, journals.duration, journals.started_at as startedAt 
+        FROM journals 
+        INNER JOIN journals_dogs ON journals.id = journals_dogs.journal_id
+        WHERE journals.user_id = ?
+          AND journals_dogs.dog_id = ?
+          AND journals.started_at >= ?
+          AND journals.started_at < ?
+      `,
+            [userId, dogId, startDate, endDate],
+        );
     }
 
-    private getTotal(journals: Journals[]): { totalWalkCnt: number; totalDistance: number; totalTime: number } {
+    private getTotal(journals: DogWalkJournalEntry[]): {
+        totalWalkCnt: number;
+        totalDistance: number;
+        totalTime: number;
+    } {
         const totals = journals.reduce(
             (acc, journal) => {
                 acc.totalWalkCnt += 1;
@@ -292,7 +300,11 @@ export class JournalsService {
         return this.getTotal(dogJournals);
     }
 
-    private aggregateJournalsByDate(journals: Journals[], startDate: Date, endDate: Date): { [date: string]: number } {
+    private aggregateJournalsByDate(
+        journals: DogWalkJournalEntry[],
+        startDate: Date,
+        endDate: Date,
+    ): { [date: string]: number } {
         const journalCntAMonth: { [date: string]: number } = {};
 
         const currentDate = new Date(startDate);

--- a/backend/src/journals/journals.service.ts
+++ b/backend/src/journals/journals.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { Excrements } from 'src/excrements/excrements.entity';
 import { DeleteResult, EntityManager, FindOptionsWhere, In, InsertResult } from 'typeorm';
 import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';

--- a/backend/src/journals/types/journal-info.type.ts
+++ b/backend/src/journals/types/journal-info.type.ts
@@ -1,5 +1,16 @@
 import { IsDate, IsInt, IsNumber } from 'class-validator';
 
+interface JournalWalkDistance {
+    distance: number;
+    duration: number;
+}
+
+interface JournalWalkDate {
+    startedAt: Date;
+}
+
+export type DogWalkJournalEntry = JournalWalkDistance & JournalWalkDate;
+
 export class JournalInfoForList {
     @IsNumber()
     journalId: number;

--- a/backend/test/journals.e2e-spec.ts
+++ b/backend/test/journals.e2e-spec.ts
@@ -379,8 +379,8 @@ describe('JournalsController (e2e)', () => {
                     startedAt: '2024-06-12T00:00:00Z',
                     duration: 3600,
                     routes: [
-                        { lat: 87.4, lng: 85.222 },
-                        { lat: 75.23, lng: 104.4839 },
+                        [87.4, 85.222],
+                        [75.23, 104.4839],
                     ],
                     photoUrls: ['1/photo1.jpeg', '1/photo2.png'],
                     memo: 'Enjoyed the walk with Buddy!',
@@ -388,12 +388,12 @@ describe('JournalsController (e2e)', () => {
                 excrements: [
                     {
                         dogId: 1,
-                        fecesLocations: [{ lat: '87.4', lng: '85.222' }],
-                        urineLocations: [{ lat: '87.4', lng: '85.222' }],
+                        fecesLocations: [[87.4, 85.222]],
+                        urineLocations: [[87.4, 85.222]],
                     },
                     {
                         dogId: 2,
-                        fecesLocations: [{ lat: '75.23', lng: '104.4839' }],
+                        fecesLocations: [[75.23, 104.4839]],
                         urineLocations: [],
                     },
                 ],


### PR DESCRIPTION
## 작업 내용 (Content)
- `STRAIGNT_JOIN` 구문으로 더 적은 row를 반환하는 journals 테이블을 먼저 조인하도록 조인 순서를 강제하였습니다. 이를 통해 조인시 loop 수가 줄어드게 됩니다.
- user_id와 started_at을 함께 인덱싱하는 복합 인덱스를 추가하였습니다. 인덱스 스캔으로만 조건을 검사할 수 있어 속도가 빨라집니다.
이를 통해 cost를 457 -> 85.4로 약 81% 개선했습니다.

## 링크 (Links)
성능 개선 문서 : https://www.notion.so/do0ori/3b142e13e4e9402ea138ce2a34db4f19
블로그 링크 1: https://velog.io/@anna951/MySQL-TypeORM-%EC%BF%BC%EB%A6%AC-%ED%8A%9C%EB%8B%9D-1-%EC%A1%B0%EC%9D%B8-%EC%88%9C%EC%84%9C-%EB%B3%80%EA%B2%BD%ED%95%98%EA%B8%B0
블로그 링크 2: https://velog.io/@anna951/MySQL-TypeORM-%EC%BF%BC%EB%A6%AC-%ED%8A%9C%EB%8B%9D-2-%EB%B3%B5%ED%95%A9-%EC%9D%B8%EB%8D%B1%EC%8A%A4-%EC%B6%94%EA%B0%80%ED%95%98%EA%B8%B0


## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
