### PR TITLE
frontend/DANG-1198: 이미지 파일 확장자를 image/[파일타입]으로 가져오는 문제 수정

### DIFF
--- a/frontend/src/pages/Journals/CreateForm.tsx
+++ b/frontend/src/pages/Journals/CreateForm.tsx
@@ -164,13 +164,21 @@ function CreateForm() {
         navigate('/');
     }
 
+    function getFileType(file: File) {
+        let fileType: string = file.type.split('/').pop()?.toLowerCase() || '';
+        if (fileType === '') {
+            fileType = file.name.split('.').pop()?.toLowerCase() || '';
+        }
+        return fileType;
+    }
+
     async function handleAddImages(e: FormEvent<HTMLInputElement>) {
         const files = e.currentTarget.files;
 
         if (files === null) return;
         setIsUploading(true);
 
-        const fileTypes = Array.from(files).map((file) => file.type);
+        const fileTypes: string[] = Array.from(files).map((file) => getFileType(file));
         const uploadUrlResponses = await getUploadUrl(fileTypes);
         const uploadUrls = uploadUrlResponses.map((uploadUrlResponse) => uploadUrlResponse.url);
 


### PR DESCRIPTION
- 사용자가 업로드한 이미지 파일의 확장자를 가져올 때 file 객체의 type필드를 파싱하지 않아  image/[파일타입]의 형식으로 저장되어
presignedUrl 발급요청에 실패하는 버그가 있어
/를 기준으로 split 해서 확장자만 가져올 수 있게 수정했습니다
혹시 type에서 가져오지 못하는 경우 파일 이름에서 가져올 수 있도록 예외처리 하였습니다

## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
