### PR TITLE
frontend/DANG-1200: 일지 생성,수정,상세정보 api 컬럼명 변경에 따른 리팩토링

### DIFF
--- a/frontend/src/api/journal.ts
+++ b/frontend/src/api/journal.ts
@@ -36,7 +36,7 @@ interface JournalCreateForm {
         startedAt: string;
         duration: number;
         routes: Coords[];
-        photoUrls: string[];
+        journalPhotos: string[];
         memo: string;
     };
     excrements: Array<Excrement>;
@@ -53,10 +53,10 @@ export interface JournalDetail {
         id: number;
         routes: Array<Coords>;
         memo: string;
-        photoUrls: Array<string>;
+        journalPhotos: Array<string>;
+        excrementCount?: Array<ExcrementCounts>;
     };
     dogs: Array<DogAvatar>;
-    excrements?: Array<ExcrementCounts>;
 }
 
 interface ExcrementCounts {
@@ -67,5 +67,5 @@ interface ExcrementCounts {
 
 interface JournalUpdateForm {
     memo?: string;
-    photoUrls?: Array<string>;
+    journalPhotos?: Array<string>;
 }

--- a/frontend/src/constants/keys.ts
+++ b/frontend/src/constants/keys.ts
@@ -17,6 +17,7 @@ const queryKeys = {
     SUNSET_SUNRISE: 'sunsetSunrise',
     WEATHER: 'weather',
     JOURNALS: 'journals',
+    JOURNAL: 'journal',
 } as const;
 
 const storageKeys = {

--- a/frontend/src/hooks/useJournal.ts
+++ b/frontend/src/hooks/useJournal.ts
@@ -1,25 +1,27 @@
 import { JournalDetail, fetchJournal } from '@/api/journal';
+import { queryKeys } from '@/constants';
 import { useStore } from '@/store';
+import { useQuery } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 
 const useJournal = (journalId: number) => {
     const isSignedIn = useStore((state) => state.isSignedIn);
     const [journal, setJournal] = useState<JournalDetail>({
-        journalInfo: { id: 0, routes: [], memo: '', photoUrls: [] },
+        journalInfo: { id: 0, routes: [], memo: '', journalPhotos: [], excrementCount: [] },
         dogs: [],
+    });
+    const { data, isSuccess } = useQuery<JournalDetail>({
+        queryKey: [queryKeys.JOURNAL, journalId],
+        queryFn: () => fetchJournal(journalId),
+        staleTime: 0,
+        enabled: isSignedIn,
     });
 
     useEffect(() => {
-        if (isSignedIn) {
-            const asyncFunction = async () => {
-                const fetchedJournal = await fetchJournal(journalId);
-                setJournal(fetchedJournal);
-            };
-            asyncFunction();
-        }
-    }, [isSignedIn]);
+        if (data) setJournal(data);
+    }, [isSuccess]);
 
-    return journal;
+    return journal as JournalDetail;
 };
 
 export default useJournal;

--- a/frontend/src/pages/Journals/CreateForm.tsx
+++ b/frontend/src/pages/Journals/CreateForm.tsx
@@ -51,7 +51,7 @@ function CreateForm() {
         calories,
         duration,
         startedAt: serializedStartedAt,
-        photoUrls: photoFileNames,
+        journalPhotos: photoFileNames,
         routes,
     } = receivedState;
     const startedAt = new Date(serializedStartedAt);
@@ -135,7 +135,7 @@ function CreateForm() {
             startedAt: startedAt.toJSON(),
             duration,
             routes,
-            photoUrls: photoFileNames ?? [],
+            journalPhotos: imageFileNames ?? [],
             memo: textAreaRef.current?.value ?? '',
         };
         const excrements = dogs.map((dog) => {
@@ -209,7 +209,7 @@ interface ReceivedState {
     routes: Coords[];
     calories: number;
     duration: number;
-    photoUrls: string[];
+    journalPhotos: string[];
 }
 
 export type ImageFileName = string;

--- a/frontend/src/pages/Walk.tsx
+++ b/frontend/src/pages/Walk.tsx
@@ -26,7 +26,7 @@ export interface DogWalkData {
     startedAt: string | undefined;
     distance: number | undefined;
     routes: Coords[] | undefined;
-    photoUrls: string[] | undefined;
+    journalPhotos: string[] | undefined;
 }
 export interface JournalCreateFromState extends DogWalkData {
     calories: number;
@@ -43,8 +43,8 @@ function Walk() {
     const { show: showToast } = useToast();
     const spinnerAdd = useStore((state) => state.spinnerAdd);
     const spinnerRemove = useStore((state) => state.spinnerRemove);
-    const photoUrls = useStore((state) => state.photoUrls);
-    const setPhotoUrls = useStore((state) => state.setPhotoUrls);
+    const journalPhotos = useStore((state) => state.journalPhotos);
+    const setJournalPhotos = useStore((state) => state.setJournalPhotos);
     const resetWalkData = useStore((state) => state.resetWalkData);
     const handleBottomSheet = () => {
         setIsDogBottomSheetOpen(!isDogBottomSheetOpen);
@@ -69,7 +69,7 @@ function Walk() {
             resetWalkData();
             await delay(400);
             navigate('/journals/create', {
-                state: { dogs, distance, duration, calories: getCalories(distance), startedAt, routes, photoUrls },
+                state: { dogs, distance, duration, calories: getCalories(distance), startedAt, routes, journalPhotos },
             });
         }
 
@@ -96,7 +96,7 @@ function Walk() {
         if (files === null) return;
 
         const filenames = await uploadImages(files);
-        setPhotoUrls(filenames);
+        setJournalPhotos(filenames);
         showToast('사진이 저장되었습니다 :)');
     };
 

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -21,7 +21,7 @@ export const useStore = create<AuthState & CropState & LoginBottomSheetState & S
                 routes: state.routes,
                 distance: state.distance,
                 startedAt: state.startedAt,
-                photoUrls: state.photoUrls,
+                journalPhotos: state.journalPhotos,
             }),
             storage: createJSONStorage(() => localStorage),
         })(...args),

--- a/frontend/src/store/walkStore.ts
+++ b/frontend/src/store/walkStore.ts
@@ -7,7 +7,7 @@ const initialState: State = {
     distance: 0,
     startedAt: '',
     routes: [],
-    photoUrls: [],
+    journalPhotos: [],
 };
 
 const createWalkSlice: StateCreator<StateAndActions, [['zustand/devtools', never], ['zustand/persist', unknown]]> = (
@@ -35,8 +35,8 @@ const createWalkSlice: StateCreator<StateAndActions, [['zustand/devtools', never
     setStartedAt: (startedAt: string) => {
         set({ startedAt }, false, 'walk/setStartedAt');
     },
-    setPhotoUrls: (photoUrls: string[]) => {
-        set((state) => ({ photoUrls: [...state.photoUrls, ...photoUrls] }), false, 'walk/setPhotoUrls');
+    setJournalPhotos: (journalPhotos: string[]) => {
+        set((state) => ({ journalPhotos: [...state.journalPhotos, ...journalPhotos] }), false, 'walk/setJournalPhotos');
     },
     resetWalkData: () => {
         set(initialState, false, 'walk/resetWalkData');
@@ -48,7 +48,7 @@ interface State {
     routes: Coords[];
     distance: number;
     startedAt: string;
-    photoUrls: string[];
+    journalPhotos: string[];
 }
 interface Actions {
     setWalkingDogs: (dogs: WalkingDog[]) => void;
@@ -58,7 +58,7 @@ interface Actions {
     addRoutes: (routes: Coords) => void;
     setRoutes: (routes: Coords[]) => void;
     setStartedAt: (startedAt: string) => void;
-    setPhotoUrls: (photoUrls: string[]) => void;
+    setJournalPhotos: (journalPhotos: string[]) => void;
     resetWalkData: () => void;
 }
 export interface StateAndActions extends State, Actions {}


### PR DESCRIPTION
## 작업 내용 (Content)
- 산책일지 생성 수정 상세정보 api 컬럼명 수정에 따른 frontend 변수명 수정
- useJournal react-query로 리팩토링
- 상세정보 수정시 image 타입 수정 추가
- 상세정보 수정 후 해당 상세정보 queryKey 무효화하여 새로운 data fetching


## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
