### PR TITLE
frontend/DANG-1206: 비동기 문제로 알고리즘이 적용된 경로가 저장되지 않는 문제 수정

### DIFF
--- a/frontend/src/hooks/useGeolocation.ts
+++ b/frontend/src/hooks/useGeolocation.ts
@@ -75,10 +75,16 @@ const useGeolocation = () => {
     };
 
     const stopGeo = () => {
-        setIsStartGeo(false);
+        return new Promise<Coords[]>((resolve) => {
+            setIsStartGeo(false);
 
-        const simplifiedRoutes = applyRDP(routes);
-        setRoutes(simplifiedRoutes);
+            setRoutes((prevRoutes) => {
+                const simplifiedRoutes = applyRDP(prevRoutes);
+                resolve(simplifiedRoutes);
+
+                return simplifiedRoutes;
+            });
+        });
     };
 
     useEffect(() => {

--- a/frontend/src/pages/Walk.tsx
+++ b/frontend/src/pages/Walk.tsx
@@ -63,13 +63,21 @@ function Walk() {
         if (!dogs.length) return;
         spinnerAdd();
         stopClock();
-        stopGeo();
+        const simplifiedRoutes = await stopGeo();
         const ok = await requestWalkStop(dogs.map((d) => d.id));
         if (ok) {
             resetWalkData();
             await delay(400);
             navigate('/journals/create', {
-                state: { dogs, distance, duration, calories: getCalories(distance), startedAt, routes, journalPhotos },
+                state: {
+                    dogs,
+                    distance,
+                    duration,
+                    calories: getCalories(distance),
+                    startedAt,
+                    routes: simplifiedRoutes,
+                    journalPhotos,
+                },
             });
         }
 

--- a/frontend/src/store/walkStore.ts
+++ b/frontend/src/store/walkStore.ts
@@ -29,8 +29,14 @@ const createWalkSlice: StateCreator<StateAndActions, [['zustand/devtools', never
     addRoutes: (route: Coords) => {
         set((state) => ({ routes: [...state.routes, route] }), false, 'walk/addRoutes');
     },
-    setRoutes: (routes: Coords[]) => {
-        set({ routes }, false, 'walk/setRoutes');
+    setRoutes: (routesOrUpdateFn: Coords[] | ((prevRoutes: Coords[]) => Coords[])) => {
+        set(
+            (state) => ({
+                routes: typeof routesOrUpdateFn === 'function' ? routesOrUpdateFn(state.routes) : routesOrUpdateFn,
+            }),
+            false,
+            'walk/setRoutes'
+        );
     },
     setStartedAt: (startedAt: string) => {
         set({ startedAt }, false, 'walk/setStartedAt');
@@ -56,7 +62,7 @@ interface Actions {
     setDistance: (distance: number) => void;
     addDistance: (distance: number) => void;
     addRoutes: (routes: Coords) => void;
-    setRoutes: (routes: Coords[]) => void;
+    setRoutes: (routesOrUpdateFn: Coords[] | ((prevRoutes: Coords[]) => Coords[])) => void;
     setStartedAt: (startedAt: string) => void;
     setJournalPhotos: (journalPhotos: string[]) => void;
     resetWalkData: () => void;


### PR DESCRIPTION
- setRoutes가 콜백 함수를 사용하도록 변경
- setRoutes가 프로미스를 반환하고, stopWalk에서 이를 await로 받도록 변경

## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
