### PR TITLE
frontend/DANG-1208: 산책 중지 시 연관 없는 비동기 작업 Promise.allSettled로 병렬 처리

### DIFF
--- a/frontend/src/hooks/useGeolocation.ts
+++ b/frontend/src/hooks/useGeolocation.ts
@@ -75,14 +75,21 @@ const useGeolocation = () => {
     };
 
     const stopGeo = () => {
-        return new Promise<Coords[]>((resolve) => {
+        return new Promise<Coords[]>((resolve, reject) => {
             setIsStartGeo(false);
 
             setRoutes((prevRoutes) => {
-                const simplifiedRoutes = applyRDP(prevRoutes);
-                resolve(simplifiedRoutes);
-
-                return simplifiedRoutes;
+                try {
+                    const simplifiedRoutes = applyRDP(prevRoutes);
+                    if (prevRoutes.length && !simplifiedRoutes) {
+                        throw new Error('경로가 비어있습니다');
+                    }
+                    setTimeout(() => resolve(simplifiedRoutes), 0);
+                    return simplifiedRoutes;
+                } catch (error: any) {
+                    setTimeout(() => reject(new Error('경로 변환에 실패했습니다: ' + error.message)), 0);
+                    return prevRoutes;
+                }
             });
         });
     };


### PR DESCRIPTION
> ## 작업 내용 (Content)
- stopGeo 함수와 requestWalkStop 함수를 Promise.allSettled로 병렬 실행
- stopGeo 함수가 실패하더라도, 산책 중지 요청은 보내야 하기에 allSettled를 사용했음
- stopGeo에서 applyRDP 함수 실패시 이전 경로를 저장하도록 변경

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
