### PR TITLE
backend/DANG-1213: unexpected end of JSON에러 fix

### DIFF
--- a/backend/src/journals/journals.service.ts
+++ b/backend/src/journals/journals.service.ts
@@ -83,12 +83,9 @@ export class JournalsService {
         );
 
         journalInfo.id = journalId;
-        this.logger.debug('before route: ' + journalInfoRaw.routes);
-        journalInfo.routes = JSON.parse(journalInfoRaw.routes);
-        this.logger.debug('before journalPhotos: ' + journalInfoRaw.journalPhotos);
-        journalInfo.journalPhotos = JSON.parse(journalInfoRaw.journalPhotos);
-        this.logger.debug('before excrementCount: ' + journalInfoRaw.excrementCount);
-        journalInfo.excrementCount = JSON.parse(journalInfoRaw.excrementCount);
+        journalInfo.routes = journalInfoRaw.routes ? JSON.parse(journalInfoRaw.routes) : [];
+        journalInfo.journalPhotos = journalInfoRaw.journalPhotos ? JSON.parse(journalInfoRaw.journalPhotos) : '';
+        journalInfo.excrementCount = journalInfoRaw.excrementCount ? JSON.parse(journalInfoRaw.excrementCount) : {};
 
         return journalInfo;
     }


### PR DESCRIPTION
- 테스트 환경에서 routes가 지워지고, 백업 데이터와 최신 데이터 사이 갭이 생겨 그 사이에 있던 산책일지 조회시 JSON.parse의 인자로 빈 데이터가 들어가서 발생한 에러였다.
- 데이터 유무를 확인하는 예외처리 로직을 추가했다.
- 사실 산책일지 생성시 데이터가 없어도 "", [] 등 디폴트로 비어있는 값이 할당되어 실제로는 이러한 상황은 발생하면 안된다. 하지만 테스트 환경에서는 빈번하게 발생할 수 있을 것 같고, 실제 환경에서도 혹시 모를 경우가 있으니 추가했다.

## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
