### PR TITLE
backend/DANG-1211: 산책일지 목록 조회 쿼리에 현재 유저의 user_id인지 확인하는 Where 조건 추가

### DIFF
--- a/backend/src/journals/journals.controller.ts
+++ b/backend/src/journals/journals.controller.ts
@@ -37,8 +37,9 @@ export class JournalsController {
     async getJournalList(
         @Query('dogId', ParseIntPipe) dogId: number,
         @Query('date', DateValidationPipe) date: string,
+        @User() user: AccessTokenPayload,
     ): Promise<JournalListResponse[]> {
-        return await this.journalsService.getJournalList(dogId, date);
+        return await this.journalsService.getJournalList(user.userId, dogId, date);
     }
 
     @Post()

--- a/backend/src/journals/journals.service.ts
+++ b/backend/src/journals/journals.service.ts
@@ -304,7 +304,7 @@ export class JournalsService {
         return Promise.resolve(this.aggregateJournalsByDate(dogJournals, startDate, endDate));
     }
 
-    private async getJournalIdsByDogIdAndDate(dogId: number, date: string): Promise<number[]> {
+    private async getJournalIdsByDogIdAndDate(userId: number, dogId: number, date: string): Promise<number[]> {
         const startEndDate = getStartAndEndOfDay(new Date(date));
 
         const result = await this.entityManager
@@ -319,6 +319,7 @@ export class JournalsService {
             ])
             .innerJoin(JournalsDogs, 'journals_dogs', 'journals.id = journals_dogs.journal_id')
             .where('journals_dogs.dog_id = :dogId', { dogId })
+            .andWhere('journals.user_id = :userId', { userId })
             .andWhere('journals.started_at >= :startDate', { startDate: startEndDate.startDate })
             .andWhere('journals.started_at < :endDate', { endDate: startEndDate.endDate })
             .getRawMany();
@@ -329,8 +330,8 @@ export class JournalsService {
         }));
     }
 
-    async getJournalList(dogId: number, date: string): Promise<JournalListResponse[]> {
-        const journalListRaw = await this.getJournalIdsByDogIdAndDate(dogId, date);
+    async getJournalList(userId: number, dogId: number, date: string): Promise<JournalListResponse[]> {
+        const journalListRaw = await this.getJournalIdsByDogIdAndDate(userId, dogId, date);
         if (!journalListRaw.length) {
             return [];
         }


### PR DESCRIPTION
- 기존 쿼리에 해당 조건이 누락되어 있어 추가했습니다.
- 추후 강아지 공유 기능이 생긴다면, user_id 조건을 빼고 dog_id로만 조회하고, 산책일지 조회 페이지에 산책자가 누구인지 넣는 게 좀 더 사용자 입장에서 편할 것 같다는 생각도 들었습니다. 

## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
