### PR TITLE
backend/DANG-1216:  prod 빌드 시 prepare 명령어 동작하지 않게 변경

### DIFF
--- a/backend/server/Dockerfile
+++ b/backend/server/Dockerfile
@@ -42,7 +42,7 @@ COPY --chown=nestjs:nodejs . .
 
 RUN if [ ! -d "/app/log" ]; then mkdir -p /app/log; fi && \
     npm run build && \
-    npm ci --omit=dev && \
+    npm ci --ignore-scripts --omit=dev && \
     npm cache clean --force
 
 USER nestjs


### PR DESCRIPTION
- 앞선 티켓에서 husky를 dev dependency로 변경했었음
- ci 단계에서 자동으로 npm prepare 명령어가 돌아가서 빌드 오류 발생
- npm ci의 옵션으로 --ignore-scripts를 주어 에러 방지

## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
