### PR TITLE
backend/DANG-1217: git hook 원격에 없는 브랜치일 경우 분기 처리

### DIFF
--- a/backend/.husky/pre-push
+++ b/backend/.husky/pre-push
@@ -66,15 +66,21 @@ cd backend && check_and_start_mysql_container
 
 # Get the range of commits being pushed
 if [ -z "$1" ]; then
-    # If pushing current branch
-    range="origin/$(git rev-parse --abbrev-ref HEAD)@{push}"
+    # 현재 브랜치 이름 변수에 저장 
+    current_branch=$(git rev-parse --abbrev-ref HEAD)
+    # 원격 저장소에 해당 브랜치가 있는지 확인
+    if git rev-parse --verify origin/$current_branch > /dev/null 2>&1; then
+        range="origin/$current_branch..HEAD"
+    else
+        range="$(git merge-base origin/main HEAD)..HEAD"
+    fi
 else
     # If pushing to a specific remote and branch
     range="$1"
 fi
 
 # Get list of changed files in the backend directory
-changed_files=$(git diff --name-only origin/$(git rev-parse --abbrev-ref HEAD) HEAD -- "$backend_dir")
+changed_files=$(git diff --name-only $range -- "$backend_dir")
 
 # Check if there are changes in the weather-api-module directory
 if echo "$changed_files" | grep -q "^backend/weather-api-module/"; then


### PR DESCRIPTION
- 원격에 푸시되지 않은 브랜치에 대한 분기 처리가 안되어있어 새 브랜치를 푸시할 때 오류 발생
- 원격에 없는 경우에 대한 분기 처리

## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
