### PR TITLE
backend/DANG-1228: 한시간 단위 날씨 실황 데이터 저장 로직 구현

### DIFF
--- a/backend/weather-api-module/package-lock.json
+++ b/backend/weather-api-module/package-lock.json
@@ -11,12 +11,14 @@
                 "@types/ioredis": "^5.0.0",
                 "cross-env": "^7.0.3",
                 "dotenv": "^16.4.5",
-                "ioredis": "^5.4.1"
+                "ioredis": "^5.4.1",
+                "xml2js": "^0.6.2"
             },
             "devDependencies": {
                 "@swc/cli": "^0.3.10",
                 "@swc/core": "^1.5.0",
                 "@swc/jest": "^0.2.29",
+                "@types/xml2js": "^0.4.14",
                 "@typescript-eslint/eslint-plugin": "^6.21.0",
                 "@typescript-eslint/parser": "^6.21.0",
                 "eslint": "^8.57.0",
@@ -1762,6 +1764,15 @@
             "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
             "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
             "dev": true
+        },
+        "node_modules/@types/xml2js": {
+            "version": "0.4.14",
+            "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.14.tgz",
+            "integrity": "sha512-4YnrRemBShWRO2QjvUin8ESA41rH+9nQGLUGZV/1IDhi3SL9OhdpNC/MrulTWuptXKwhx/aDxE7toV0f/ypIXQ==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*"
+            }
         },
         "node_modules/@types/yargs": {
             "version": "17.0.33",
@@ -7399,6 +7410,11 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/sax": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+            "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg=="
+        },
         "node_modules/semver": {
             "version": "7.6.3",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
@@ -8486,6 +8502,26 @@
             },
             "engines": {
                 "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
+        "node_modules/xml2js": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+            "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+            "dependencies": {
+                "sax": ">=0.6.0",
+                "xmlbuilder": "~11.0.0"
+            },
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
+        "node_modules/xmlbuilder": {
+            "version": "11.0.1",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+            "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+            "engines": {
+                "node": ">=4.0"
             }
         },
         "node_modules/y18n": {

--- a/backend/weather-api-module/package.json
+++ b/backend/weather-api-module/package.json
@@ -22,6 +22,7 @@
         "@swc/cli": "^0.3.10",
         "@swc/core": "^1.5.0",
         "@swc/jest": "^0.2.29",
+        "@types/xml2js": "^0.4.14",
         "@typescript-eslint/eslint-plugin": "^6.21.0",
         "@typescript-eslint/parser": "^6.21.0",
         "eslint": "^8.57.0",
@@ -42,6 +43,7 @@
         "@types/ioredis": "^5.0.0",
         "cross-env": "^7.0.3",
         "dotenv": "^16.4.5",
-        "ioredis": "^5.4.1"
+        "ioredis": "^5.4.1",
+        "xml2js": "^0.6.2"
     }
 }

--- a/backend/weather-api-module/src/parse-data.ts
+++ b/backend/weather-api-module/src/parse-data.ts
@@ -1,8 +1,17 @@
-import { todayWeatherPredicate, WeatherData, WeatherDataMap } from './weather-type';
+import {
+    OneHourWeatherRealRaw,
+    TodayWeatherPredicateRaw,
+    TodayWeatherPredicateData,
+    TodayWeatherPredicateDataMap,
+    OneHourRealWeatherDataMap,
+} from './weather-type';
+export interface ParseData<T, U> {
+    parse(data: T): U;
+}
 
-export class ParseData {
-    parseTodayWeatherPredicate(weatherDataList: todayWeatherPredicate[]): WeatherDataMap {
-        const consolidatedData: { [key: string]: WeatherData } = {};
+export class parseTodayWeatherPredicate implements ParseData<TodayWeatherPredicateRaw[], TodayWeatherPredicateDataMap> {
+    parse(weatherDataList: TodayWeatherPredicateRaw[]): TodayWeatherPredicateDataMap {
+        const consolidatedData: { [key: string]: TodayWeatherPredicateData } = {};
 
         weatherDataList.forEach((weatherData) => {
             const key = weatherData.fcstTime;
@@ -39,6 +48,37 @@ export class ParseData {
     }
 }
 
-export function getParserInstance(): ParseData {
-    return new ParseData();
+export class parseRealWeatherOneHour implements ParseData<OneHourWeatherRealRaw[], OneHourRealWeatherDataMap> {
+    parse(weatherDataList: OneHourWeatherRealRaw[]): OneHourRealWeatherDataMap {
+        const consolidatedData: OneHourRealWeatherDataMap = {};
+
+        weatherDataList.forEach((weatherData) => {
+            const key = weatherData.baseTime;
+            if (!consolidatedData[key]) {
+                consolidatedData[key] = {
+                    temperature: 0,
+                    precipitation: 0,
+                };
+            }
+
+            switch (weatherData.category) {
+                case 'T1H':
+                    consolidatedData[key].temperature = Number(weatherData.obsrValue);
+                    break;
+                case 'PTY':
+                    consolidatedData[key].precipitation = Number(weatherData.obsrValue);
+                    break;
+            }
+        });
+
+        return consolidatedData;
+    }
+}
+
+export function getTodayParserInstance(): ParseData<TodayWeatherPredicateRaw[], TodayWeatherPredicateDataMap> {
+    return new parseTodayWeatherPredicate();
+}
+
+export function getRealWeatherOneHour(): ParseData<OneHourWeatherRealRaw[], OneHourRealWeatherDataMap> {
+    return new parseRealWeatherOneHour();
 }

--- a/backend/weather-api-module/src/public-weather-error.ts
+++ b/backend/weather-api-module/src/public-weather-error.ts
@@ -1,0 +1,8 @@
+
+
+export class publicWeatherAPIError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'XMLParseError';
+    }
+}

--- a/backend/weather-api-module/src/urlBuilder.ts
+++ b/backend/weather-api-module/src/urlBuilder.ts
@@ -11,8 +11,7 @@ export class UrlBuilder {
 
     setApiType(apiType: WeatherApiType) {
         if (apiType === 'predicateDay') this.apiTypeSignature = 'getVilageFcst';
-        if (apiType === 'predicateSixHour') this.apiTypeSignature = 'getUltrSrtFcst';
-        if (apiType === 'realtimeOneHour') this.apiTypeSignature = 'getUltrSrtNcst';
+        if (apiType === 'realtimeOneHour') this.apiTypeSignature = 'getUltraSrtNcst';
         return this;
     }
 

--- a/backend/weather-api-module/src/util.ts
+++ b/backend/weather-api-module/src/util.ts
@@ -1,0 +1,5 @@
+export function getCurrentTimeKey(): string {
+    const now = new Date();
+    const hour = now.getHours().toString().padStart(2, '0');
+    return hour + '00';
+}

--- a/backend/weather-api-module/src/weather-type.ts
+++ b/backend/weather-api-module/src/weather-type.ts
@@ -1,16 +1,6 @@
-export interface WeatherData {
-    maxTemperature: number;
-    minTemperature: number;
-    temperature: number;
-    sky: number;
-    precipitation: number;
-}
+export type WeatherApiType = 'realtimeOneHour' | 'predicateDay';
 
-export type WeatherApiType = 'realtimeOneHour' | 'predicateDay' | 'predicateSixHour';
-
-export type WeatherDataMap = {[key: string]: WeatherData};
-
-export interface todayWeatherPredicate {
+export interface TodayWeatherPredicateRaw {
     baseDate: string;
     baseTime: string;
     category: string;
@@ -20,3 +10,28 @@ export interface todayWeatherPredicate {
     nx: number;
     ny: number;
 }
+
+export interface OneHourWeatherRealRaw {
+    baseDate: string;
+    baseTime: string;
+    category: string;
+    obsrValue: string;
+    nx: number;
+    ny: number;
+}
+
+export interface TodayWeatherPredicateData {
+    maxTemperature: number;
+    minTemperature: number;
+    temperature: number;
+    sky: number;
+    precipitation: number;
+}
+
+export interface OneHourWeatherRealData {
+    temperature: number;
+    precipitation: number;
+}
+
+export type TodayWeatherPredicateDataMap = { [key: string]: TodayWeatherPredicateData };
+export type OneHourRealWeatherDataMap = { [key: string]: OneHourWeatherRealData };

--- a/backend/weather-api-module/src/xml-util.ts
+++ b/backend/weather-api-module/src/xml-util.ts
@@ -1,0 +1,27 @@
+import { promisify } from 'util';
+
+import { parseString } from 'xml2js';
+
+interface errorXML {
+    OpenAPI_ServiceResponse: {
+        cmmMsgHeader: [
+            {
+                errMsg: string[];
+                returnAuthMsg: string[];
+                returnReasonCode: string[];
+            },
+        ];
+    };
+}
+
+const parseXML = promisify(parseString);
+export async function parseErrorCode(error: string): Promise<string> {
+    const errorXML: errorXML = (await parseXML(error)) as errorXML;
+    const errorMsg = errorXML.OpenAPI_ServiceResponse.cmmMsgHeader[0].returnAuthMsg[0];
+    return errorMsg;
+}
+
+export function isXML(str: string): boolean {
+    const trimmed = str.trim();
+    return trimmed.startsWith('<') && trimmed.endsWith('>');
+}


### PR DESCRIPTION
## 작업 내용 (Content)
한시간 단위로 제공되는 실제 관측 데이터를 가져와 저장하는 로직을 구현했습니다.
- 10분단위인줄 알았는데 한시간 단위로 제공되어 10분 단위로 쪼개서 저장하던 로직을 없애고 한시간 단위로 통일
- 코드 중복을 없애기 위해 parse라는 하나의 인터페이스로 두 가지 데이터에 대한 파싱을 할 수 있도록 구현

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
