### PR TITLE
backend/DANG-1236: env.TAG 오류 수정

### DIFF
--- a/.github/workflows/backend_weather_deploy.yaml
+++ b/.github/workflows/backend_weather_deploy.yaml
@@ -8,7 +8,6 @@ on:
 
 env:
   IMAGE: dangdangwalk/weather-api-module
-  TAG: ${GITHUB_SHA::7}
 
 jobs:
   build:
@@ -45,6 +44,8 @@ jobs:
         with:
           username: ${{secrets.DOCKERHUB_USERNAME}}
           password: ${{secrets.DOCKERHUB_TOKEN}}
+      - name: Set TAG
+        run: echo "TAG=$(echo $GITHUB_SHA | cut -c1-7)" >> $GITHUB_ENV
       - name: Docker build
         run: |
           docker build --platform linux/amd64 -t ${{ env.IMAGE }} --target prod -f weather-api-module/Dockerfile .
@@ -58,14 +59,14 @@ jobs:
   deploy:
     name: Oracle Instance Deploy
     needs: build
-    runs-on: [self-hosted, label-weather] 
+    runs-on: [self-hosted, label-weather]
     steps:
       - name: Create .env
         env:
           ENV_FILE: ${{ secrets.ENV_FILE_BACKEND_WEATHER }}
         run: |
           if [ ! -d "backend/weather-api-module" ]; then 
-            mkdir backend/weather-api-module;  
+            mkdir -p backend/weather-api-module;  
           fi
           echo "$ENV_FILE" > ./backend/weather-api-module/.env.prod
       - name: Setup Redis
@@ -73,7 +74,7 @@ jobs:
           REDIS_PORT=$(grep REDIS_PORT ./backend/weather-api-module/.env.prod | cut -d '=' -f2)
           REDIS_PORT=${REDIS_PORT:-6379}
 
-          Add `runs-on: self-hosted` to your workflow's YAML to send jobs to this runner.if ! docker ps -a | grep -q redis-container; then
+          if ! docker ps -a | grep -q redis-container; then
           echo "Redis container does not exist, creating new one..."
           docker volume create redis_data
           docker run -d --name redis-container \

--- a/backend/weather-api-module/src/weather/weather-controller.ts
+++ b/backend/weather-api-module/src/weather/weather-controller.ts
@@ -10,7 +10,6 @@ import { getLogger } from '../logger/logger-factory';
 import { WinstonLoggerService } from '../logger/winston-logger';
 import { getCurrentTimeKey } from '../util';
 
-//TODO: erase
 export class Controller {
     private dataStore: DataStore;
     private weatherService: WeatherService;


### PR DESCRIPTION
## 작업 내용 (Content)
깃허브 액션 yaml에서 GITHUB_SHA:7 에 쓰인 쉘 스크립트 확장 문법이 지원되지 않을 수 있다고 해서
TAG를 설정하는 단계를 따로 만들었다.
backend_deploy는 잘 돌아가는 걸 보면 이 문제가 아닐 수도 있다. 


## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
