### PR TITLE
backend/DANG-1260: 홈 화면 statistics api 캐시 불일치 문제 수정

### DIFF
--- a/backend/server/src/common/database/database.module.ts
+++ b/backend/server/src/common/database/database.module.ts
@@ -52,6 +52,7 @@ import { WinstonLoggerService } from '../logger/winstonLogger.service';
                     ...(enableQueryLogger
                         ? { logger: new FileLogger(true, { logPath: `log/ormlogs.${nodeEnv}.log` }) }
                         : {}),
+                    logging: process.env.NODE_ENV === 'local',
                 };
             },
             async dataSourceFactory(options) {

--- a/backend/server/src/const/cache-const.ts
+++ b/backend/server/src/const/cache-const.ts
@@ -1,0 +1,9 @@
+export const EVENTS = {
+    JOURNAL_CREATED: 'journal.created',
+    JOURNAL_DELETED: 'journal.deleted',
+    DOG_CREATED: 'dog.created',
+    DOG_UPDATED: 'dog.updated',
+    DOG_DELETED: 'dog.deleted',
+} as const;
+
+export const CACHE_TTL = 1000 * 60 * 60;

--- a/backend/server/src/statistics/statistics.service.ts
+++ b/backend/server/src/statistics/statistics.service.ts
@@ -99,19 +99,15 @@ export class StatisticsService {
     @OnEvent(EVENTS.DOG_UPDATED)
     @OnEvent(EVENTS.JOURNAL_CREATED)
     @OnEvent(EVENTS.JOURNAL_DELETED)
-    async updateDogWalkingStatisticsCache(payload: { userId: number }) {
+    async invalidateUserDogStatisticsCache(payload: { userId: number }) {
+        this.logger.debug(`handleJournalCreated 이벤트 수신 시간: ${new Date().toISOString()}`);
         const { userId } = payload;
         const cacheKey = this.generateCacheKey(userId);
         try {
-            const overviewData = await this.getDogsWeeklyWalkingOverviewData(userId);
-
-            await this.cacheManager.set(cacheKey, overviewData, CACHE_TTL);
-            this.logger.log('statistics 캐시 데이터를 업데이트 했습니다.');
-            this.logger.debug(JSON.stringify(overviewData));
-        } catch (error) {
-            this.logger.error(`캐시 업데이트 중 오류 발생: ${error.message}`, error.stack);
             await this.cacheManager.del(cacheKey);
             this.logger.log(`유저 ${payload.userId}의 캐시를 무효화했습니다.`);
+        } catch (error) {
+            this.logger.error(`캐시 삭제 중 오류 발생: ${error.message}`, error.stack);
         }
     }
 


### PR DESCRIPTION
## 작업 내용 (Content)
1. 누락된 이벤트 추가
- 기존에는 산책일지 생성 시에만 캐시를 업데이트 하게 되어있어서 산책일지 삭제, 강아지 생성/수정/삭제시에 DB와 캐시사이 불일치 문제가 발생했습니다
- 누락된 이벤트를 추가했습니다

2. 이벤트 수신시 캐시를 업데이트하는 방식에서 캐시를 무효화 하는 방식으로 수정
- 배경 : 산책일지 삭제시, 강아지 두 마리 이상을 산책시킨 산책일지를 삭제했을 때 빈번하게 캐시가 업데이트 되지 않은 상태로 남아있는 버그 발생
- 원인 : 트랜잭션이 끝나기 전에 이벤트 수신
- 이벤트 수신 로그만 COMMIT 이전에 찍히고 실제 데이터를 가져오는 쿼리는 COMMIT 이후에 찍히고 있었지만, 미묘한 타이밍 문제로 트랜잭션의 변경사항이 반영되기 전 데이터를 가져오는 것으로 보임
- 강아지가 두마리 이상일 때 더 많은 데이터를 조작하기에 자주 데이터 불일치가 발생하는 것으로 추정됨
- 이를 해결하기 위해 이벤트 수신시 캐시를 삭제하고, 다시 홈 화면에 접속했을 때 데이터를 가져오도록 데이터의 fetch 타이밍을 뒤로 미루는 방식을 사용하도록 변경
- setImmediate를 사용하는 방법보다 이 방법이 좀 더 직관적이고 버그 가능성이 낮은 것 같아 선택했습니다


## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
