### PR TITLE
infra/DANG-1267: workflow에서 swagger-ui-updates branch에서의 event는 무시하도록 수정

### DIFF
--- a/.github/workflows/change_ticket_status_done.yaml
+++ b/.github/workflows/change_ticket_status_done.yaml
@@ -3,6 +3,8 @@ name: Change Ticket Status to Done
 on:
   pull_request:
     types: [closed]
+    branches-ignore:
+      - swagger-ui-updates
 
 jobs:
   change_ticket_status_to_done_if_merged:

--- a/.github/workflows/link_pr_to_ticket.yaml
+++ b/.github/workflows/link_pr_to_ticket.yaml
@@ -3,6 +3,8 @@ name: Link PR to Ticket
 on:
   pull_request:
     types: [opened]
+    branches-ignore:
+      - swagger-ui-updates
 
 jobs:
   link_pr_to_ticket:

--- a/.github/workflows/pr_labeler_validator.yaml
+++ b/.github/workflows/pr_labeler_validator.yaml
@@ -3,6 +3,8 @@ name: Labeler and Validator
 on:
   pull_request:
     types: [opened, edited]
+    branches-ignore:
+      - swagger-ui-updates
 
 jobs:
   label_and_validate:


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- PR event와 관련된 workflow 파일들에서 swagger-ui-updates에서의 event는 무시하도록 수정

## 링크 (Links)
https://www.notion.so/do0ori/workflow-swagger-ui-updates-branch-event-13f8ad358684807aa110c19a60760a98

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
