### PR TITLE
backend/DANG-862: error logging 중앙화

### DIFF
--- a/backend/server/src/app.module.ts
+++ b/backend/server/src/app.module.ts
@@ -1,13 +1,14 @@
 import { CacheModule } from '@nestjs/cache-manager';
 import { Module, Scope } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
-import { APP_INTERCEPTOR } from '@nestjs/core';
+import { APP_FILTER, APP_INTERCEPTOR } from '@nestjs/core';
 import { EventEmitterModule } from '@nestjs/event-emitter';
 import { PrometheusModule } from '@willsoto/nestjs-prometheus';
 
 import { AppController } from './app.controller';
 import { AuthModule } from './auth/auth.module';
 import { DatabaseModule } from './common/database/database.module';
+import { AllExceptionsFilter } from './common/filters/all-exceptions.filter';
 import { HealthController } from './common/health/health.controller';
 import { LoggingInterceptor } from './common/interceptors/logging.interceptor';
 import { ProfilingInterceptor } from './common/interceptors/profilingInterceptor';
@@ -46,6 +47,10 @@ import { WalkModule } from './walk/walk.module';
             provide: APP_INTERCEPTOR,
             scope: Scope.REQUEST,
             useClass: LoggingInterceptor,
+        },
+        {
+            provide: APP_FILTER,
+            useClass: AllExceptionsFilter,
         },
         ...(process.env.ENABLE_PROFILING === 'true'
             ? [

--- a/backend/server/src/auth/auth.service.ts
+++ b/backend/server/src/auth/auth.service.ts
@@ -59,7 +59,6 @@ export class AuthService {
             if (error instanceof NotFoundException) {
                 return { oauthAccessToken, oauthRefreshToken, provider };
             }
-            this.logger.error(`로그인 에러`, { trace: error.stack ?? '스택 없음' });
             throw error;
         }
     }

--- a/backend/server/src/auth/guards/auth.guard.ts
+++ b/backend/server/src/auth/guards/auth.guard.ts
@@ -3,7 +3,6 @@ import { Reflector } from '@nestjs/core';
 import { JsonWebTokenError, TokenExpiredError } from '@nestjs/jwt';
 import { Request } from 'express';
 
-import { WinstonLoggerService } from '../../common/logger/winstonLogger.service';
 import { AuthService } from '../auth.service';
 import { SKIP } from '../decorators/public.decorator';
 
@@ -12,7 +11,6 @@ export class AuthGuard implements CanActivate {
     constructor(
         private authService: AuthService,
         private reflector: Reflector,
-        private logger: WinstonLoggerService,
     ) {}
 
     async canActivate(context: ExecutionContext): Promise<boolean> {
@@ -28,13 +26,9 @@ export class AuthGuard implements CanActivate {
             return true;
         } catch (error) {
             if (error instanceof TokenExpiredError || error instanceof JsonWebTokenError) {
-                error = new UnauthorizedException(error.message);
-                this.logger.error(error.message, { trace: error.stack ?? 'No stack' });
-                throw error;
+                throw new UnauthorizedException(error.message, { cause: error });
             } else {
-                error = new UnauthorizedException();
-                this.logger.error(error.message, { trace: error.stack ?? 'No stack' });
-                throw error;
+                throw new UnauthorizedException();
             }
         }
     }
@@ -53,21 +47,15 @@ export class AuthGuard implements CanActivate {
         const authorizationHeader = request.headers.authorization;
 
         if (!authorizationHeader) {
-            const error = new UnauthorizedException('헤더에 Authorization 필드가 없습니다');
-            this.logger.error(`헤더에 Authorization 필드가 없습니다`, { trace: error.stack ?? 'No stack' });
-            throw error;
+            throw new UnauthorizedException('헤더에 Authorization 필드가 없습니다');
         }
 
         const [type, token] = authorizationHeader.split(' ');
 
         if (!token || type !== 'Bearer') {
-            const error = new UnauthorizedException(
-                'Token does not exist in Authorization header or is in an invalid format.',
-            );
-            this.logger.error(`헤더의 Authorization 필드에 토큰이 없거나, 형식이 잘못되었습니다`, {
-                trace: error.stack ?? 'No stack',
+            throw new UnauthorizedException('헤더의 Authorization 필드에 토큰이 없거나, 형식이 잘못되었습니다', {
+                cause: { authorizationHeader },
             });
-            throw error;
         }
 
         return token;

--- a/backend/server/src/auth/guards/oauth-data.guard.ts
+++ b/backend/server/src/auth/guards/oauth-data.guard.ts
@@ -1,11 +1,7 @@
 import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
 
-import { WinstonLoggerService } from '../../common/logger/winstonLogger.service';
-
 @Injectable()
 export class OauthDataGuard implements CanActivate {
-    constructor(private readonly logger: WinstonLoggerService) {}
-
     async canActivate(context: ExecutionContext): Promise<boolean> {
         const request = context.switchToHttp().getRequest();
         const oauthData = this.extractOauthDataFromCookies(request);
@@ -29,11 +25,7 @@ export class OauthDataGuard implements CanActivate {
                 .filter(Boolean)
                 .join(', ');
 
-            const error = new UnauthorizedException(`쿠키에 OAuth 데이터가 없습니다: ${missingFields}`);
-            this.logger.error(`OAuthDataGuard : ${missingFields} 필드가 없습니다`, {
-                trace: error.stack ?? '스택 없음',
-            });
-            throw error;
+            throw new UnauthorizedException(`쿠키에 OAuth 데이터(${missingFields})가 없습니다`);
         }
 
         return { oauthAccessToken, oauthRefreshToken, provider };

--- a/backend/server/src/auth/interceptors/cookie.interceptor.ts
+++ b/backend/server/src/auth/interceptors/cookie.interceptor.ts
@@ -3,17 +3,13 @@ import { ConfigService } from '@nestjs/config';
 import { CookieOptions, Response } from 'express';
 import { Observable, map } from 'rxjs';
 
-import { WinstonLoggerService } from '../../common/logger/winstonLogger.service';
 import { TokenService } from '../token/token.service';
 import { AuthData } from '../types/auth-data.type';
 import { OauthData } from '../types/oauth-data.type';
 
 @Injectable()
 export class CookieInterceptor implements NestInterceptor {
-    constructor(
-        private configService: ConfigService,
-        private logger: WinstonLoggerService,
-    ) {}
+    constructor(private configService: ConfigService) {}
 
     private readonly isProduction = this.configService.get<string>('NODE_ENV') === 'prod';
 
@@ -44,13 +40,9 @@ export class CookieInterceptor implements NestInterceptor {
                     return { accessToken: data.accessToken };
                 } else if ('oauthAccessToken' in data && 'oauthRefreshToken' in data && 'provider' in data) {
                     this.setOauthCookies(response, data);
-
-                    const error = new NotFoundException('일치하는 유저를 찾을 수 없습니다. 계정을 생성해주세요');
-                    this.logger.error(
-                        `일치하는 유저를 찾을 수 없습니다. 계정을 생성해주세요`,
-                        error.stack ?? '스택 없음',
-                    );
-                    throw error;
+                    throw new NotFoundException('일치하는 유저를 찾을 수 없습니다. 계정을 생성해주세요', {
+                        cause: data,
+                    });
                 }
             }),
         );

--- a/backend/server/src/common/database/typeorm.repository.ts
+++ b/backend/server/src/common/database/typeorm.repository.ts
@@ -43,7 +43,9 @@ export abstract class TypeORMRepository<T extends ObjectLiteral> implements IBas
         const existingEntity = await this.entityRepository.findOne({ where });
 
         if (existingEntity) {
-            throw new ConflictException('createIfNotExists: 이미 존재하는 레코드입니다');
+            throw new ConflictException('createIfNotExists: 이미 존재하는 레코드입니다', {
+                cause: { where },
+            });
         }
 
         return this.create(entity);
@@ -61,7 +63,9 @@ export abstract class TypeORMRepository<T extends ObjectLiteral> implements IBas
         const entity = await this.entityRepository.findOne(where);
 
         if (!entity) {
-            throw new NotFoundException('findOne: 존재하지 않는 레코드입니다');
+            throw new NotFoundException('findOne: 존재하지 않는 레코드입니다', {
+                cause: { where },
+            });
         }
 
         return entity;
@@ -71,7 +75,9 @@ export abstract class TypeORMRepository<T extends ObjectLiteral> implements IBas
         const result = this.entityRepository.find(where);
 
         if (!result) {
-            throw new NotFoundException('find: 존재하지 않는 레코드입니다');
+            throw new NotFoundException('find: 존재하지 않는 레코드입니다', {
+                cause: { where },
+            });
         }
 
         return result;
@@ -81,7 +87,9 @@ export abstract class TypeORMRepository<T extends ObjectLiteral> implements IBas
         const updateResult = await this.entityRepository.update(where, partialEntity);
 
         if (!updateResult.affected) {
-            throw new NotFoundException('update: 존재하지 않는 레코드입니다');
+            throw new NotFoundException('update: 존재하지 않는 레코드입니다', {
+                cause: { where, partialEntity },
+            });
         }
 
         return updateResult;
@@ -91,7 +99,9 @@ export abstract class TypeORMRepository<T extends ObjectLiteral> implements IBas
         const deleteResult = await this.entityRepository.delete(where);
 
         if (!deleteResult.affected) {
-            throw new NotFoundException('delete: 존재하지 않는 레코드입니다');
+            throw new NotFoundException('delete: 존재하지 않는 레코드입니다', {
+                cause: { where },
+            });
         }
 
         return deleteResult;
@@ -101,7 +111,9 @@ export abstract class TypeORMRepository<T extends ObjectLiteral> implements IBas
         const updateResult = await this.entityRepository.update(where, partialEntity);
 
         if (!updateResult.affected) {
-            throw new NotFoundException('update: 존재하지 않는 레코드입니다');
+            throw new NotFoundException('update: 존재하지 않는 레코드입니다', {
+                cause: { where, partialEntity },
+            });
         }
         const options: FindOneOptions = { where };
 

--- a/backend/server/src/common/filters/all-exceptions.filter.ts
+++ b/backend/server/src/common/filters/all-exceptions.filter.ts
@@ -1,0 +1,49 @@
+import { ArgumentsHost, Catch, ExceptionFilter, HttpException, HttpStatus } from '@nestjs/common';
+
+import { WinstonLoggerService } from '../logger/winstonLogger.service';
+
+@Catch()
+export class AllExceptionsFilter implements ExceptionFilter {
+    constructor(private readonly logger: WinstonLoggerService) {}
+
+    catch(exception: unknown, host: ArgumentsHost) {
+        const ctx = host.switchToHttp();
+        const response = ctx.getResponse();
+        const request = ctx.getRequest();
+
+        const requestId = request.requestId || 'N/A';
+        const userTag = request.userTag || 'UNKNOWN';
+
+        let status: number;
+        let message: string;
+        let cause: any;
+
+        if (exception instanceof HttpException) {
+            status = exception.getStatus();
+            const responseObj = exception.getResponse();
+            message = typeof responseObj === 'string' ? responseObj : (responseObj as any).message || 'Unknown error';
+            cause = exception.cause || null;
+        } else {
+            status = HttpStatus.INTERNAL_SERVER_ERROR;
+            message = (exception as Error)?.message || 'Internal server error';
+        }
+
+        const logLevel = status < 500 ? 'warn' : 'error';
+        this.logger[logLevel](message, {
+            type: 'EXCEPTION',
+            method: request.method,
+            path: request.url,
+            ip: request.ip,
+            status,
+            userTag,
+            requestId,
+            trace: (exception as Error)?.stack,
+            details: cause,
+        });
+
+        response.status(status).json({
+            statusCode: status,
+            message,
+        });
+    }
+}

--- a/backend/server/src/common/interceptors/logging.interceptor.ts
+++ b/backend/server/src/common/interceptors/logging.interceptor.ts
@@ -27,6 +27,9 @@ export class LoggingInterceptor implements NestInterceptor {
         const requestId = generateUuid();
         const { ip, method, path: url } = request;
 
+        request.requestId = requestId;
+        request.userTag = user;
+
         if (url === '/metrics') {
             return next.handle().pipe();
         }

--- a/backend/server/src/dogs/guards/auth-dog.guard.ts
+++ b/backend/server/src/dogs/guards/auth-dog.guard.ts
@@ -1,14 +1,10 @@
 import { BadRequestException, CanActivate, ExecutionContext, ForbiddenException, Injectable } from '@nestjs/common';
 
-import { WinstonLoggerService } from '../../common/logger/winstonLogger.service';
 import { UsersService } from '../../users/users.service';
 
 @Injectable()
 export class AuthDogGuard implements CanActivate {
-    constructor(
-        private readonly usersService: UsersService,
-        private readonly logger: WinstonLoggerService,
-    ) {}
+    constructor(private readonly usersService: UsersService) {}
 
     async canActivate(context: ExecutionContext): Promise<boolean> {
         const request = context.switchToHttp().getRequest();
@@ -24,11 +20,7 @@ export class AuthDogGuard implements CanActivate {
         const id = request.query.dogId || request.params.id;
 
         if (!this.isInt(id)) {
-            const error = new BadRequestException('dogId가 정수가 아닙니다');
-            this.logger.error('dogId가 정수가 아닙니다', {
-                trace: error.stack ?? '스택 없음',
-            });
-            throw error;
+            throw new BadRequestException('dogId가 정수가 아닙니다', { cause: { id } });
         }
 
         return parseInt(id);
@@ -38,9 +30,7 @@ export class AuthDogGuard implements CanActivate {
         const [owned] = await this.usersService.checkDogOwnership(userId, dogId);
 
         if (!owned) {
-            const error = new ForbiddenException(`유저 ${userId}은/는 강아지${dogId}의 주인이 아닙니다`);
-            this.logger.error(`유저 ${userId}은/는 ${dogId}의 주인이 아닙니다`, { trace: error.stack ?? '스택 없음' });
-            throw error;
+            throw new ForbiddenException(`유저 ${userId}은/는 강아지${dogId}의 주인이 아닙니다`);
         }
     }
 

--- a/backend/server/src/journals/guards/auth-journal.guard.ts
+++ b/backend/server/src/journals/guards/auth-journal.guard.ts
@@ -1,14 +1,10 @@
 import { CanActivate, ExecutionContext, ForbiddenException, Injectable } from '@nestjs/common';
 
-import { WinstonLoggerService } from '../../common/logger/winstonLogger.service';
 import { JournalsService } from '../journals.service';
 
 @Injectable()
 export class AuthJournalGuard implements CanActivate {
-    constructor(
-        private readonly journalsService: JournalsService,
-        private readonly logger: WinstonLoggerService,
-    ) {}
+    constructor(private readonly journalsService: JournalsService) {}
 
     async canActivate(context: ExecutionContext): Promise<boolean> {
         const request = context.switchToHttp().getRequest();
@@ -24,13 +20,7 @@ export class AuthJournalGuard implements CanActivate {
         const [owned] = await this.journalsService.checkJournalOwnership(userId, journalId);
 
         if (!owned) {
-            const error = new ForbiddenException(
-                `유저 ${userId}은/는 산책일지 ${journalId}에 대한 접근 권한이 없습니다`,
-            );
-            this.logger.error(`유저 ${userId}은/는 산책일지 ${journalId}에 대한 접근 권한이 없습니다`, {
-                trace: error.stack ?? '스택 없음',
-            });
-            throw error;
+            throw new ForbiddenException(`유저 ${userId}은/는 산책일지 ${journalId}에 대한 접근 권한이 없습니다`);
         }
     }
 }

--- a/backend/server/src/today-walk-time/today-walk-time.service.ts
+++ b/backend/server/src/today-walk-time/today-walk-time.service.ts
@@ -40,11 +40,7 @@ export class TodayWalkTimeService {
     ): Promise<void> {
         const todayWalkTimes = await this.findWalkTimesByIds(walkTimeIds);
         if (!todayWalkTimes.length) {
-            const error = new NotFoundException(`id: ${walkTimeIds}와 일치하는 레코드가 없습니다`);
-            this.logger.error(`id: ${walkTimeIds}와 일치하는 레코드가 없습니다`, {
-                trace: error.stack ?? '스택 없음',
-            });
-            throw error;
+            throw new NotFoundException(`id: ${walkTimeIds}와 일치하는 레코드가 없습니다`);
         }
 
         const updateEntities: Partial<TodayWalkTime>[] = todayWalkTimes.map(

--- a/backend/server/src/walk/guards/auth-dogs.guard.ts
+++ b/backend/server/src/walk/guards/auth-dogs.guard.ts
@@ -1,15 +1,11 @@
 import { BadRequestException, CanActivate, ExecutionContext, ForbiddenException, Injectable } from '@nestjs/common';
 
-import { WinstonLoggerService } from '../../common/logger/winstonLogger.service';
 import { UsersService } from '../../users/users.service';
 import { isTypedArray } from '../../utils/validator.util';
 
 @Injectable()
 export class AuthDogsGuard implements CanActivate {
-    constructor(
-        private readonly usersService: UsersService,
-        private readonly logger: WinstonLoggerService,
-    ) {}
+    constructor(private readonly usersService: UsersService) {}
 
     async canActivate(context: ExecutionContext): Promise<boolean> {
         const request = context.switchToHttp().getRequest();
@@ -25,11 +21,7 @@ export class AuthDogsGuard implements CanActivate {
         const body = request.body.dogs || request.body;
 
         if (!isTypedArray(body, 'number')) {
-            const error = new BadRequestException('유효하지 않은 request body: dogIds가 number 타입의 배열이 아닙니다');
-            this.logger.error('유효하지 않은 request body: dogIds가 number 타입의 배열이 아닙니다', {
-                trace: error.stack ?? 'No stack',
-            });
-            throw error;
+            throw new BadRequestException('dogIds가 number 타입의 배열이 아닙니다', { cause: { body } });
         }
 
         return body;
@@ -39,16 +31,9 @@ export class AuthDogsGuard implements CanActivate {
         const [owned, notFoundDogIds] = await this.usersService.checkDogOwnership(userId, dogIds);
 
         if (!owned) {
-            const error = new ForbiddenException(
+            throw new ForbiddenException(
                 `유저 ${userId}은/는 다음 강아지(들)에 대한 접근 권한이 없습니다: ${notFoundDogIds.join(', ')}`,
             );
-            this.logger.error(
-                `유저 ${userId}은/는 다음 강아지(들)에 대한 접근 권한이 없습니다: ${notFoundDogIds.join(', ')}`,
-                {
-                    trace: error.stack ?? 'No stack',
-                },
-            );
-            throw error;
         }
     }
 }


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- 전역 예외 처리를 추가해 예외 로깅 중앙화
- 시스템 외적인 요인으로 발생하는 오류는 로그 레벨을 `warn`으로 설정하고, 복구 불가능한 시스템 오류는 `error`로 설정.
- 로그에는 cause 정보를 포함해 자세한 정보 제공, response는 statusCode와 message만 반환.
- `WinstonLoggerService`를 사용한 로깅 제거 -> throw를 던지면 exception filter가 알아서 logging을 찍어준다.

## 링크 (Links)
https://www.notion.so/do0ori/1-error-logging-2ee24d4afe1f4d23bb6b115d3eb15912

## 기타 사항 (Etc)
- 외부 API를 사용하는 로직에 대해서는 작업을 하지 못함.

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
