### PR TITLE
backend/DANG-1275: Logging 타입 명시 추가

### DIFF
--- a/backend/server/src/shared/logger/console-logger.ts
+++ b/backend/server/src/shared/logger/console-logger.ts
@@ -5,8 +5,8 @@ import * as winston from 'winston';
 
 import * as winstonDaily from 'winston-daily-rotate-file';
 
+import { directory, isProduction, isTest } from '../utils';
 import stripAnsi from '../utils/ansi.util';
-import { isProduction, isTest, directory } from '../utils/etc';
 
 export function createLogger(): winston.Logger {
     if (!(isTest || fs.existsSync(directory))) {
@@ -14,7 +14,7 @@ export function createLogger(): winston.Logger {
     }
 
     const consoleLogFormat = winston.format.printf(({ timestamp, level, message, ...meta }) => {
-        const seoulTimestamp = new Date(timestamp).toLocaleString('ko-KR');
+        const seoulTimestamp = new Date(timestamp as string).toLocaleString('ko-KR');
         const metaString = Object.keys(meta).length > 0 ? `\n${JSON.stringify(meta, null, 2)}` : '';
         return `${seoulTimestamp} | ${level}| ${message}${metaString}`;
     });
@@ -45,7 +45,7 @@ export function createLogger(): winston.Logger {
         maxSize: '20m',
         maxFiles: '14d',
         format: winston.format.combine(
-            winston.format((info) => ({ ...info, message: stripAnsi(info.message) }))(),
+            winston.format((info) => ({ ...info, message: stripAnsi(info.message as string) }))(),
             winston.format.timestamp(),
             winston.format.json(),
         ),

--- a/backend/server/test/test-utils.ts
+++ b/backend/server/test/test-utils.ts
@@ -1,34 +1,35 @@
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getDataSourceToken } from '@nestjs/typeorm';
+import { DogWalkDay } from 'applications/dog-walk-day/dog-walk-day.entity';
+import { Journals } from 'applications/journals/journals.entity';
+import { JournalsDogs } from 'applications/journals-dogs/journals-dogs.entity';
 import * as cookieParser from 'cookie-parser';
+import { S3Service } from 'infrastructure/aws/s3/s3.service';
 import * as request from 'supertest';
 
 import { AllMethods } from 'supertest/types';
 
+import { DataSource, In } from 'typeorm';
 import { initializeTransactionalContext } from 'typeorm-transactional';
 
 import { EXPIRED_ACCESS_TOKEN, INVALID_USER_ID_ACCESS_TOKEN, MALFORMED_ACCESS_TOKEN } from './constants';
 
-import { INestApplication } from '../node_modules/@nestjs/common';
-import { Test, TestingModule } from '../node_modules/@nestjs/testing';
-import { getDataSourceToken } from '../node_modules/@nestjs/typeorm';
+import { MockOauthService } from './performance/__mocks__/oauth.service';
 
-import { DataSource, In } from '../node_modules/typeorm';
+import { MockS3Service } from './performance/__mocks__/s3.service';
 
 import { AppModule } from '../src/app.module';
-
-import { Dogs } from '../src/applications/dogs/dogs.entity';
-import { Journals } from '../src/applications/journals/journals.entity';
-import { Users } from '../src/applications/users/users.entity';
-import { MockOauthService } from '../src/auth/oauth/__mocks__/oauth.service';
-import { GoogleService } from '../src/auth/oauth/google.service';
-import { KakaoService } from '../src/auth/oauth/kakao.service';
-import { NaverService } from '../src/auth/oauth/naver.service';
-import { DogWalkDay } from '../src/dog-walk-day/dog-walk-day.entity';
-import { Excrements } from '../src/excrements/excrements.entity';
-import { MockS3Service } from '../src/infrastructure/aws/s3/__mocks__/s3.service';
-import { S3Service } from '../src/infrastructure/aws/s3/s3.service';
-import { JournalsDogs } from '../src/journals-dogs/journals-dogs.entity';
-import { TodayWalkTime } from '../src/today-walk-time/today-walk-time.entity';
-import { UsersDogs } from '../src/users-dogs/users-dogs.entity';
+import {
+    Dogs,
+    Excrements,
+    GoogleService,
+    KakaoService,
+    NaverService,
+    TodayWalkTime,
+    Users,
+    UsersDogs,
+} from '../src/applications';
 
 let app: INestApplication;
 let dataSource: DataSource;

--- a/backend/weather-api-module/src/logger/winston-logger.ts
+++ b/backend/weather-api-module/src/logger/winston-logger.ts
@@ -23,7 +23,7 @@ export class WinstonLoggerService {
         }
 
         const consoleLogFormat = winston.format.printf(({ timestamp, level, message, ...meta }) => {
-            const seoulTimestamp = new Date(timestamp).toLocaleString('ko-KR');
+            const seoulTimestamp = new Date(timestamp as string).toLocaleString('ko-KR');
             const metaString = Object.keys(meta).length > 0 ? `\n${JSON.stringify(meta, null, 2)}` : '';
             return `${seoulTimestamp} | ${level}| ${message}${metaString}`;
         });
@@ -53,7 +53,7 @@ export class WinstonLoggerService {
                 maxSize: '20m',
                 maxFiles: '14d',
                 format: winston.format.combine(
-                    winston.format((info) => ({ ...info, message: stripAnsi(info.message) }))(),
+                    winston.format((info) => ({ ...info, message: stripAnsi(info.message as string) }))(),
                     winston.format.timestamp(),
                     winston.format.json(),
                 ),
@@ -67,7 +67,7 @@ export class WinstonLoggerService {
                 maxFiles: '14d',
                 level: 'error',
                 format: winston.format.combine(
-                    winston.format((info) => ({ ...info, message: stripAnsi(info.message) }))(),
+                    winston.format((info) => ({ ...info, message: stripAnsi(info.message as string) }))(),
                     winston.format.timestamp(),
                     winston.format.json(),
                 ),


### PR DESCRIPTION
코드 리팩토링 및 의존성 경로 수정, 타입 명시 추가

주요 변경사항:
1. `console-logger.ts` 파일에서 의존성 경로 수정 및 타입 명시 추가
2. `test-utils.ts` 파일에서 의존성 경로 수정 및 불필요한 import 제거
3. `typeorm` 관련 초기화 코드 추가
4. `MockOauthService` 및 `MockS3Service` 경로 수정

## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
