### PR TITLE
infra/DANG-1280: run_backend.sh에 health check 실패 시 컨테이너 로그를 추출해 출력하는 기능 추가

### DIFF
--- a/.github/script/run_backend.sh
+++ b/.github/script/run_backend.sh
@@ -104,6 +104,17 @@ verify_container_health() {
   done
 
   log_error "Health check failed after $HEALTH_CHECK_MAX_RETRIES attempts."
+  log_info "Fetching recent logs from the container..."
+
+  local container_name=$(docker ps --filter "publish=$port" --format "{{.Names}}")
+
+  if [ -n "$container_name" ]; then
+    log_info "Container name: $container_name"
+    docker logs "$container_name" | awk '/\[Nest\].*LOG \[InstanceLoader\]/{p=NR+1}(NR>=p && p!=0)'
+  else
+    log_error "No running container found on port $port."
+  fi
+
   exit 1
 }
 

--- a/.github/script/test_run_backend.sh
+++ b/.github/script/test_run_backend.sh
@@ -152,6 +152,18 @@ case "$1" in
         fi
         exit 0
         ;;
+    "logs")
+        echo "[Nest] 1  - 01/14/2025, 2:32:56 PM     LOG [NestFactory] Starting Nest application..."
+        echo "[Nest] 1  - 01/14/2025, 2:32:57 PM     LOG [InstanceLoader] AppModule dependencies initialized"
+        echo "node:fs:596"
+        echo "  handleErrorFromBinding(ctx);"
+        echo "Error: ENOENT: no such file or directory, open './resources/breedData.json'"
+        ;;
+    "ps")
+        if [ "$3" = "publish=3031" ] || [ "$3" = "publish=3032" ]; then
+            echo "dangdang-api-${MOCK_CURRENT_CONTAINER:-blue}"
+        fi
+        ;;
     "pull"|"stop"|"rm"|"run"|"image")
         echo "[MOCK] Docker $1 executed"
         exit "${MOCK_DOCKER_EXIT_CODE:-0}"
@@ -305,7 +317,16 @@ test_health_check_failure() {
     export MOCK_HEALTH_CHECK_FAIL=true
     
     local result=0
+
     if ./run_backend.sh "test-tag" "test.env.prod" "test-repo" "test-image"; then
+        result=1
+    fi
+
+    local output
+    output=$(./run_backend.sh "test-tag" "test.env.prod" "test-repo" "test-image" 2>&1)
+
+    if ! echo "$output" | grep -q "Fetching recent logs"; then
+        echo "Expected log message 'Fetching recent logs' not found"
         result=1
     fi
     
@@ -422,7 +443,7 @@ main() {
         '
         
         context 'when health check fails' '
-            it \"should fail and rollback deployment\" test_health_check_failure
+            it \"should fail and display container logs\" test_health_check_failure
         '
     "
     


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
Health check 실패 시 원인 파악을 위해 ec2에 접속해 docker container의 log를 확인하는 번거로움을 해결하기 위해 실패한 컨테이너의 최신 로그를 가져오는 기능을 추가했습니다.

---

### 테스트 결과 (Verbose 모드)
```
   Docker Operations
     when health check fails
       ✓ should fail and display container logs (2739 ms)

Output:
         [DEBUG] Target Container Image: test-repo/test-image:test-tag
         [DEBUG] Environment File Path: /tmp/test/test.env.prod
         [INFO] Deployment arguments validated.
         [INFO] Authenticating with AWS ECR...
         [MOCK] Docker login executed
         [SUCCESS] Successfully authenticated with AWS ECR
         [INFO] Checking deployment status...
         [INFO] No active deployment found - Initiating Blue deployment...
         [INFO] Starting deployment for dangdang-api-blue on port 3032...
         [INFO] Cleaning up container: dangdang-api-blue
         [MOCK] Docker stop executed
         [MOCK] Docker rm executed
         [MOCK] Docker pull executed
         [INFO] Deploying container: dangdang-api-blue on port: 3032
         [MOCK] Docker run executed
         [INFO] Verifying container health on port: 3032
         [INFO] Retrying health check... (1/3)
         [INFO] Retrying health check... (2/3)
         [INFO] Retrying health check... (3/3)
         [ERROR] Health check failed after 3 attempts.
         [INFO] Fetching recent logs from the container...
         [INFO] Container name: dangdang-api-blue
         node:fs:596
           handleErrorFromBinding(ctx);
         Error: ENOENT: no such file or directory, open './resources/breedData.json'
```

테스트에 작성해둔 docker logs mock 출력과 비교해보면 [Nest] 라인 다음의 로그들만 추출되어 잘 출력된 것을 확인할 수 있다.
```
[Nest] 1  - 01/14/2025, 2:32:56 PM     LOG [NestFactory] Starting Nest application...
[Nest] 1  - 01/14/2025, 2:32:57 PM     LOG [InstanceLoader] AppModule dependencies initialized
node:fs:596
  handleErrorFromBinding(ctx);"
Error: ENOENT: no such file or directory, open './resources/breedData.json'
```

## 링크 (Links)
https://www.notion.so/do0ori/run_backend-sh-17b8ad35868480099f64f8750ebeed00

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
