### PR TITLE
infra/DANG-1282: 소스 브랜치가 'swagger-ui-updates'일 때 workflow 실행되지 않도록 수정

### DIFF
--- a/.github/workflows/change_ticket_status_done.yaml
+++ b/.github/workflows/change_ticket_status_done.yaml
@@ -3,12 +3,12 @@ name: Change Ticket Status to Done
 on:
   pull_request:
     types: [closed]
-    branches-ignore:
-      - swagger-ui-updates
 
 jobs:
   change_ticket_status_to_done_if_merged:
-    if: github.event.pull_request.merged == true
+    if: |
+      github.event.pull_request.merged == true &&
+      github.head_ref != 'swagger-ui-updates'
     runs-on: ubuntu-latest
     steps:
       - name: Change the status of corresponding Notion Ticket to Done
@@ -16,7 +16,7 @@ jobs:
           DATABASE_ID: 35e838520c274894b2206eb34a198575
           NOTION_API_KEY: ${{ secrets.NOTION_API_KEY }}
         run: |
-          branch_name="${{ github.event.pull_request.head.ref }}"
+          branch_name="${{ github.head_ref }}"
 
           if [[ $branch_name =~ DANG-([0-9]+)$ ]]; then
             TASK_ID="${BASH_REMATCH[1]}"


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- 기존의 `branches-ignore` 옵션은 base 브랜치를 기준으로 동작하여 의도한대로 소스 브랜치(head)가 제외되지 않음
- 소스 브랜치 제외를 위해 `github.head_ref`를 이용한 명시적 조건 추가
- 불필요한 옵션 (`branches-ignore`) 제거

## 링크 (Links)
- https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onpull_requestpull_request_targetbranchesbranches-ignore
- https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs?utm_source=chatgpt.com#github-context

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
